### PR TITLE
fix(docs): Remove trailing periods from alert content in SVG feature descriptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bug #16: Update image alt text from `Yii Framework` to `UI Awesome` (@terabytesoftw)
 - Bug #17: Enhance support for `Stringable` interface types across `BaseCssClass`, `BaseEncode`, `BaseEnum`, `BaseValidator` classes and update related tests (@terabytesoftw)
 - Bug #18: Update feature descriptions in SVG files to reflect new capabilities including `Stringable` support and performance optimizations (@terabytesoftw)
+- Bug #19: Remove trailing periods from alert content in SVG feature descriptions (@terabytesoftw)
 
 ## 0.4.0 December 17, 2025
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ composer require ui-awesome/html-helper:^0.5
 
 ### Quick start
 
-#### Universal Stringable Support (New!)
+#### Universal Stringable support
 
 Pass your domain objects directly to helpers like `Encode`, `Attributes`, or `CSSClass`. The library automatically
 handles `__toString()`.

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -67,7 +67,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Validation</strong></p>
-                    <p class="alert-content">Strict validations — int-like checks, allowed-value checks and explicit errors</p>
+                    <p class="alert-content">Strict validations int-like checks, allowed-value checks and explicit errors</p>
                 </div>
             </div>
         </div>

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -63,7 +63,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Stringable Support</strong></p>
-                    <p class="alert-content">Seamlessly use PHP 8 `Stringable` objects in attributes, classes, and content</p>
+                    <p class="alert-content">Seamlessly use PHP 8 Stringable objects in attributes, classes, and content</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Validation</strong></p>

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -47,7 +47,7 @@
             <div class="container">
                 <div class="alert-box">
                     <p class="alert-title"><strong>Framework Agnostic</strong></p>
-                    <p class="alert-content">Zero dependencies on specific frameworks.</p>
+                    <p class="alert-content">Zero dependencies on specific frameworks</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Enum Integration</strong></p>
@@ -59,7 +59,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Secure by Design</strong></p>
-                    <p class="alert-content">Automatic XSS protection via context-aware encoding.</p>
+                    <p class="alert-content">Automatic XSS protection via context-aware encoding</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Stringable Support</strong></p>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -64,7 +64,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Validation</strong></p>
-                    <p class="alert-content">Strict validations — int-like checks, allowed-value checks and explicit errors</p>
+                    <p class="alert-content">Strict validations int-like checks, allowed-value checks and explicit errors</p>
                 </div>
             </div>
         </div>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -60,7 +60,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Stringable Support</strong></p>
-                    <p class="alert-content">Seamlessly use PHP 8 `Stringable` objects in attributes, classes, and content</p>
+                    <p class="alert-content">Seamlessly use PHP 8 Stringable objects in attributes, classes, and content</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Validation</strong></p>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -44,7 +44,7 @@
             <div class="container">
                 <div class="alert-box">
                     <p class="alert-title"><strong>Framework Agnostic</strong></p>
-                    <p class="alert-content">Zero dependencies on specific frameworks.</p>
+                    <p class="alert-content">Zero dependencies on specific frameworks</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Enum Integration</strong></p>
@@ -56,7 +56,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Secure by Design</strong></p>
-                    <p class="alert-content">Automatic XSS protection via context-aware encoding.</p>
+                    <p class="alert-content">Automatic XSS protection via context-aware encoding</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Stringable Support</strong></p>


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alert text formatting in SVG feature descriptions by removing unnecessary trailing periods.

* **Documentation**
  * Updated README heading wording from "Universal Stringable Support (New!)" to "Universal Stringable support" for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->