### PR TITLE
feat(helper): Add `normalizeKey()` method in `BaseAttribute` helper for normalization attribute keys with prefixes, enhance error handling and add related tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.1 Under development
 
-- Enh #20: Add `normalizeKey()` method in `BaseAttribute` helper for normalization attribute keys with prefixes, enhance error handling and add related tests (@terabytesoftw)
+- Enh #20: Add `normalizeKey()` method in `BaseAttributes` helper for normalization attribute keys with prefixes, enhance error handling and add related tests (@terabytesoftw)
 
 ## 0.5.0 December 19, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #17: Enhance support for `Stringable` interface types across `BaseCssClass`, `BaseEncode`, `BaseEnum`, `BaseValidator` classes and update related tests (@terabytesoftw)
 - Bug #18: Update feature descriptions in SVG files to reflect new capabilities including `Stringable` support and performance optimizations (@terabytesoftw)
 - Bug #19: Remove trailing periods from alert content in SVG feature descriptions (@terabytesoftw)
+- Enh #20: Add `normalizeKey()` method in `BaseAttribute` helper for normalization attribute keys with prefixes, enhance error handling and add related tests (@terabytesoftw)
 
 ## 0.4.0 December 17, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.1 Under development
 
+- Enh #20: Add `normalizeKey()` method in `BaseAttribute` helper for normalization attribute keys with prefixes, enhance error handling and add related tests (@terabytesoftw)
+
 ## 0.5.0 December 19, 2025
 
 - Bug #15: Update copyright year to `2024` in `LICENSE` file (@terabytesoftw)
@@ -9,7 +11,6 @@
 - Bug #17: Enhance support for `Stringable` interface types across `BaseCssClass`, `BaseEncode`, `BaseEnum`, `BaseValidator` classes and update related tests (@terabytesoftw)
 - Bug #18: Update feature descriptions in SVG files to reflect new capabilities including `Stringable` support and performance optimizations (@terabytesoftw)
 - Bug #19: Remove trailing periods from alert content in SVG feature descriptions (@terabytesoftw)
-- Enh #20: Add `normalizeKey()` method in `BaseAttribute` helper for normalization attribute keys with prefixes, enhance error handling and add related tests (@terabytesoftw)
 
 ## 0.4.0 December 17, 2025
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ composer require ui-awesome/html-helper:^0.5
 
 ### Quick start
 
+#### Attribute key normalization
+
+Ensures attribute keys have the correct prefix (like `aria-`, `data-`, or `on`), supporting strings, Enums, and
+Stringables.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use UIAwesome\Html\Helper\Attributes;
+
+// normalize string key (adds prefix if missing)
+echo Attributes::normalizeKey('label', 'aria-');
+// aria-label
+
+// normalize Enum key
+echo Attributes::normalizeKey(Data::ACTION, 'data-');
+// data-action
+
+// normalize event (flexible prefixing)
+echo Attributes::normalizeKey('click', 'on');
+// onclick
+```
+
 #### Universal Stringable support
 
 Pass your domain objects directly to helpers like `Encode`, `Attributes`, or `CSSClass`. The library automatically

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -8,16 +8,17 @@ namespace UIAwesome\Html\Helper;
  * HTML attribute utility for standardized, safe attribute rendering.
  *
  * Provides a concrete implementation for rendering HTML attributes in a predictable, standards-compliant order,
- * supporting common HTML5 use cases such as boolean attributes, `class` and `style` composition, and `data-*` /
- * `aria-*` attribute expansion.
+ * supporting common HTML5 use cases such as boolean attributes, `class`, `style` composition, `data-*`, `aria-*`, and
+ * `on*` attribute expansion.
  *
  * Designed for integration in tag renderers and view helpers, ensuring consistent encoding, validation, and output
  * formatting of attribute strings across all supported use cases.
  *
  * Key features.
- * - Array handling for `class`, `style`, `data-*`, and `aria-*` attributes.
+ * - Array handling for `class`, `style`, `data-*`, `aria-*`, and `on*` attributes.
  * - Attribute sorting by priority for readable, maintainable HTML.
  * - JSON encoding for complex attribute values.
+ * - Normalization of attribute keys with specific prefixes.
  * - Support for boolean attributes (for example, `checked`, `disabled`).
  * - Validation of attribute names using a strict regex pattern.
  *

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -60,6 +60,13 @@ enum Message: string
     case INCORRECT_REGEXP = 'Incorrect regular expression or malformed pattern.';
 
     /**
+     * Error when a key is not a non-empty string.
+     *
+     * Format: "Key must be a non-empty string."
+     */
+    case KEY_MUST_BE_NON_EMPTY_STRING = 'Key must be a non-empty string.';
+
+    /**
      * Error when the length of a regular expression is less than two.
      *
      * Format: "Length of the regular expression cannot be less than '2'."

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Helper\Tests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Helper\Tests\Providers\AttributesProvider;
 
 /**
@@ -32,6 +34,16 @@ use UIAwesome\Html\Helper\Tests\Providers\AttributesProvider;
 #[Group('helpers')]
 final class AttributesTest extends TestCase
 {
+    #[DataProviderExternal(AttributesProvider::class, 'key')]
+    public function testNormalizeKeyAttribute(mixed $key, string $prefix, string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            Attributes::normalizeKey($key, $prefix),
+            'Should normalize key attribute correctly.',
+        );
+    }
+
     /**
      * @phpstan-param mixed[] $attributes
      */
@@ -108,5 +120,16 @@ final class AttributesTest extends TestCase
             Attributes::render($attributes),
             'Should render attributes as expected for each data set.',
         );
+    }
+
+    #[DataProviderExternal(AttributesProvider::class, 'invalidKey')]
+    public function testThrowInvalidArgumentExceptionWhenAttributeKeyIsInvalid(mixed $key, string $prefix): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+        );
+
+        Attributes::normalizeKey($key, $prefix);
     }
 }

--- a/tests/Providers/AttributesProvider.php
+++ b/tests/Providers/AttributesProvider.php
@@ -146,8 +146,8 @@ final class AttributesProvider
     /**
      * Provides datasets for invalid attribute keys.
      *
-     * Each dataset returns an invalid attribute key and a corresponding value. These cases cover empty strings and
-     * enum keys to ensure such invalid inputs are identified for omission.
+     * Each dataset returns an invalid attribute key and a corresponding prefix. These cases cover empty strings and
+     * enum keys to ensure such invalid inputs are identified for validation.
      *
      * @phpstan-return array<string, array{string|UnitEnum, string}>
      */
@@ -168,8 +168,8 @@ final class AttributesProvider
     /**
      * Provides datasets for attribute keys with prefixes.
      *
-     * Each dataset returns the expected normalized attribute key string, the prefix, and the input attribute key. These
-     * cases validate correct handling of prefixed attribute keys such as `aria-*`, `data-*`, and `on-*` ensuring enums
+     * Each dataset returns the input attribute key, the prefix, and the expected normalized attribute key string. These
+     * cases validate correct handling of prefixed attribute keys such as `aria-*`, `data-*`, and `on-*`, ensuring enums
      * and strings are normalized appropriately.
      *
      * @phpstan-return array<string, array{string|Stringable|UnitEnum, string, string}>

--- a/tests/Providers/AttributesProvider.php
+++ b/tests/Providers/AttributesProvider.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Helper\Tests\Providers;
 
-use UIAwesome\Html\Helper\Tests\Support\Stub\Enum\{ButtonSize, Columns, Theme};
+use Stringable;
+use UIAwesome\Html\Helper\Tests\Support\Stub\Enum\{ButtonSize, Columns, Key, Priority, Theme};
+use UnitEnum;
 
 /**
  * Data provider for {@see \UIAwesome\Html\Helper\Tests\AttributesTest} class.
  *
- * Supplies focused datasets used by attribute rendering helpers to build safe and predictable HTML attribute
- * strings.
+ * Supplies focused datasets used by attribute rendering helpers to build safe and predictable HTML attribute strings.
  *
  * The cases cover attribute ordering rules, handling of empty and `null`, enum normalization across common attribute
- * contexts, and sanitization/encoding of potentially malicious inputs.
+ * contexts, sanitization/encoding of potentially malicious inputs, and normalization of prefixed attribute keys.
  *
  * Key features.
  * - Cover enum in `class`, `data`, and `style` contexts.
  * - Exercise closures, scalars, and nested attribute groups used in tag attribute rendering.
+ * - Normalize and validate prefixed attribute keys (`aria-*`, `data-*`, `on-*`).
  * - Provide deterministic datasets for ordering and filtering attributes.
  * - Validate safe handling of invalid names and malicious attribute value.
  *
@@ -137,6 +139,118 @@ final class AttributesProvider
             'single enum' => [
                 ' type="sm"',
                 ['type' => ButtonSize::SMALL],
+            ],
+        ];
+    }
+
+    /**
+     * Provides datasets for invalid attribute keys.
+     *
+     * Each dataset returns an invalid attribute key and a corresponding value. These cases cover empty strings and
+     * enum keys to ensure such invalid inputs are identified for omission.
+     *
+     * @phpstan-return array<string, array{string|Priority, string}>
+     */
+    public static function invalidKey(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                'value',
+            ],
+            'enum key' => [
+                Priority::HIGH,
+                'value',
+            ],
+        ];
+    }
+
+    /**
+     * Provides datasets for attribute keys with prefixes.
+     *
+     * Each dataset returns the expected normalized attribute key string, the prefix, and the input attribute key. These
+     * cases validate correct handling of prefixed attribute keys such as `aria-*`, `data-*`, and `on-*` ensuring enums
+     * and strings are normalized appropriately.
+     *
+     * @phpstan-return array<string, array{string|Stringable|UnitEnum, string, string}>
+     */
+    public static function key(): array
+    {
+        return [
+            'enum with prefix aria' => [
+                Key::ARIA_LABEL,
+                'aria-',
+                'aria-label',
+            ],
+            'enum with prefix data' => [
+                Key::DATA_TOGGLE,
+                'data-',
+                'data-toggle',
+            ],
+            'enum with prefix event' => [
+                Key::ON_CLICK,
+                'on',
+                'onclick',
+            ],
+            'string key with prefix aria' => [
+                'aria-label',
+                'aria-',
+                'aria-label',
+            ],
+            'string key with prefix data' => [
+                'data-toggle',
+                'data-',
+                'data-toggle',
+            ],
+            'string key with prefix event' => [
+                'onclick',
+                'on',
+                'onclick',
+            ],
+            'stringable with prefix aria' => [
+                new class {
+                    public function __toString(): string
+                    {
+                        return 'aria-label';
+                    }
+                },
+                'aria-',
+                'aria-label',
+            ],
+            'stringable with prefix data' => [
+                new class {
+                    public function __toString(): string
+                    {
+                        return 'data-toggle';
+                    }
+                },
+                'data-',
+                'data-toggle',
+            ],
+            'stringable with prefix event' => [
+                new class {
+                    public function __toString(): string
+                    {
+                        return 'onclick';
+                    }
+                },
+                'on',
+                'onclick',
+            ],
+            'without prefix aria' => [
+                'label',
+                'aria-',
+                'aria-label',
+            ],
+            'without prefix data' => [
+                'toggle',
+                'data-',
+                'data-toggle',
+            ],
+            'without prefix event' => [
+                'click',
+                'on',
+                'onclick',
             ],
         ];
     }

--- a/tests/Providers/AttributesProvider.php
+++ b/tests/Providers/AttributesProvider.php
@@ -149,18 +149,18 @@ final class AttributesProvider
      * Each dataset returns an invalid attribute key and a corresponding value. These cases cover empty strings and
      * enum keys to ensure such invalid inputs are identified for omission.
      *
-     * @phpstan-return array<string, array{string|Priority, string}>
+     * @phpstan-return array<string, array{string|UnitEnum, string}>
      */
     public static function invalidKey(): array
     {
         return [
             'empty string' => [
                 '',
-                'value',
+                'aria-',
             ],
-            'enum key' => [
+            'enum' => [
                 Priority::HIGH,
-                'value',
+                'data-',
             ],
         ];
     }

--- a/tests/Support/Stub/Enum/Key.php
+++ b/tests/Support/Stub/Enum/Key.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Helper\Tests\Support\Stub\Enum;
+
+/**
+ * Enum type representing HTML attribute keys for testing normalization logic.
+ *
+ * Provides standardized attribute keys for test scenarios involving HTML attribute rendering and normalization.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Key: string
+{
+    /**
+     * Key representing the 'aria-label' HTML attribute.
+     */
+    case ARIA_LABEL = 'aria-label';
+
+    /**
+     * Key representing the 'data-toggle' HTML attribute.
+     */
+    case DATA_TOGGLE = 'data-toggle';
+
+    /**
+     * Key representing the 'onclick' HTML attribute.
+     */
+    case ON_CLICK = 'onclick';
+}

--- a/tests/Support/Stub/Enum/Priority.php
+++ b/tests/Support/Stub/Enum/Priority.php
@@ -19,6 +19,7 @@ enum Priority: int
      * High-priority value.
      */
     case HIGH = 2;
+
     /**
      * Low-priority value.
      */


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attribute key normalization for prefixed attributes (aria-*, data-*, on*).

* **Documentation**
  * Expanded docs and Quick Start with attribute key normalization details and examples; broadened HTML5 attribute support notes.

* **Tests**
  * Added tests and data providers for normalized keys and invalid-key error handling.

* **Chores**
  * Added a standardized error message for invalid attribute keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->