### PR TITLE
fix(validation): Allow `null` values in `oneOf` method and update related tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #21: Update group annotation from 'helpers' to 'helper' across multiple test files (@terabytesoftw)
 - Dep #22: Update `infection/infection` version constraint to `^0.32` in `composer.json` (@terabytesoftw)
+- Bug #23: Allow `null` values in `oneOf` method and update related tests (@terabytesoftw)
 
 ## 0.5.1 December 23, 2025
 

--- a/src/Base/BaseValidator.php
+++ b/src/Base/BaseValidator.php
@@ -97,7 +97,7 @@ abstract class BaseValidator
      * Normalizes the provided value and allowed list, and checks strict membership. If the value is empty or `null`,
      * validation passes.
      *
-     * @param int|string|Stringable|UnitEnum $value Value to validate.
+     * @param int|string|Stringable|UnitEnum|null $value Value to validate.
      * @param array $allowed List of allowed values for validation.
      * @param string $argumentName Argument name for error reporting (default: 'value').
      *
@@ -110,7 +110,7 @@ abstract class BaseValidator
      * // invalid case
      * Validator::oneOf('blue', ['red', 'green', 'yellow'], 'color');
      * // throws InvalidArgumentException.
-     *    "Value 'blue' for argument 'color' is not in the allowed list: 'red', 'green', 'yellow'."
+     * // "Value 'blue' for argument 'color' is not in the allowed list: 'red', 'green', 'yellow'."
      *
      * // valid case
      * Validator::oneOf(Status::ACTIVE, [Status::ACTIVE, Status::INACTIVE], 'status');
@@ -128,7 +128,7 @@ abstract class BaseValidator
      * ```
      */
     public static function oneOf(
-        int|string|Stringable|UnitEnum $value,
+        int|string|Stringable|UnitEnum|null $value,
         array $allowed,
         string $argumentName = 'value',
     ): void {

--- a/tests/Providers/ValidatorProvider.php
+++ b/tests/Providers/ValidatorProvider.php
@@ -249,8 +249,8 @@ final class ValidatorProvider
      * Provides datasets for `oneOf` validation checks.
      *
      * Each dataset returns: attribute name, tested value, allowed list, a strict comparison flag, and the expected
-     * message. Datasets cover backed enums, unit enums, mixed enum lists, scalar comparisons, and message generation
-     * for failure scenarios.
+     * message. Datasets cover backed enums, unit enums, mixed enum lists, `null`, scalar comparisons, and message
+     * generation for failure scenarios.
      *
      * @return array Test data for oneOf validation.
      *
@@ -342,6 +342,17 @@ final class ValidatorProvider
                     'attribute',
                     implode('\', \'', Enum::normalizeArray([Status::ACTIVE, Theme::DARK, Priority::LOW])),
                 ),
+            ],
+            'null value' => [
+                'attribute',
+                null,
+                [
+                    'a',
+                    'b',
+                    'c',
+                ],
+                false,
+                '',
             ],
             'string case sensitive enum value' => [
                 'attribute',

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -56,7 +56,7 @@ final class ValidatorTest extends TestCase
     #[DataProviderExternal(ValidatorProvider::class, 'oneOf')]
     public function testOneOfWithValidValues(
         string $attribute,
-        int|string|Stringable|UnitEnum $value,
+        int|string|Stringable|UnitEnum|null $value,
         array $allowed,
         bool $exception,
         string $exceptionMessage,


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * oneOf validation now accepts null/empty values so validation can pass when no value is provided.

* **Tests**
  * Added/updated test cases to cover null value scenarios for the oneOf validator.

* **Documentation**
  * Changelog and test provider descriptions updated to note null handling in oneOf.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->