### PR TITLE
fix(validation): .Update argument types in `oneOf` method and related tests to support `UnitEnum` in `argumentName` parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.3 Under development
 
+- Bug #24: Update argument types in `oneOf` method and related tests to support `UnitEnum` in `argumentName` parameter (@terabytesoftw)
+
 ## 0.5.2 December 26, 2025
 
 - Bug #21: Update group annotation from 'helpers' to 'helper' across multiple test files (@terabytesoftw)

--- a/src/Base/BaseValidator.php
+++ b/src/Base/BaseValidator.php
@@ -99,7 +99,7 @@ abstract class BaseValidator
      *
      * @param int|string|Stringable|UnitEnum|null $value Value to validate.
      * @param array $allowed List of allowed values for validation.
-     * @param string $argumentName Argument name for error reporting (default: 'value').
+     * @param string|UnitEnum $argumentName Argument name for error reporting (default: 'value').
      *
      * @throws InvalidArgumentException if the value is not in the allowed list.
      *
@@ -130,11 +130,12 @@ abstract class BaseValidator
     public static function oneOf(
         int|string|Stringable|UnitEnum|null $value,
         array $allowed,
-        string $argumentName = 'value',
+        string|UnitEnum $argumentName = 'value',
     ): void {
         $normalizedAllowedValues = Enum::normalizeArray($allowed);
         /** @phpstan-var int|string|null $normalizedValue */
         $normalizedValue = Enum::normalizeValue($value);
+        $normalizedArgumentName = Enum::normalizeValue($argumentName);
 
         if ($normalizedValue === '' || $normalizedValue === null) {
             return;
@@ -147,7 +148,7 @@ abstract class BaseValidator
         throw new InvalidArgumentException(
             Message::VALUE_NOT_IN_LIST->getMessage(
                 $normalizedValue,
-                $argumentName,
+                $normalizedArgumentName,
                 implode("', '", $normalizedAllowedValues),
             ),
         );

--- a/tests/Providers/ValidatorProvider.php
+++ b/tests/Providers/ValidatorProvider.php
@@ -8,6 +8,7 @@ use Stringable;
 use UIAwesome\Html\Helper\Enum;
 use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Helper\Tests\Support\Stub\Enum\{Priority, Status, Theme};
+use UnitEnum;
 
 /**
  * Data provider for {@see \UIAwesome\Html\Helper\Tests\ValidatorTest} class.
@@ -254,11 +255,18 @@ final class ValidatorProvider
      *
      * @return array Test data for oneOf validation.
      *
-     * @phpstan-return array<string, array{string, mixed, list<mixed>, bool, string}>
+     * @phpstan-return array<string, array{string|UnitEnum, mixed, list<mixed>, bool, string}>
      */
     public static function oneOf(): array
     {
         return [
+            'backed enum in argument name' => [
+                Status::ACTIVE,
+                Status::INACTIVE,
+                Status::cases(),
+                false,
+                '',
+            ],
             'backed enum value in list' => [
                 'attribute',
                 Status::ACTIVE,

--- a/tests/Providers/ValidatorProvider.php
+++ b/tests/Providers/ValidatorProvider.php
@@ -260,12 +260,23 @@ final class ValidatorProvider
     public static function oneOf(): array
     {
         return [
-            'backed enum in argument name' => [
+            'backed enum argument name' => [
                 Status::ACTIVE,
                 Status::INACTIVE,
                 Status::cases(),
                 false,
                 '',
+            ],
+            'backed enum argument name not in list' => [
+                Status::ACTIVE,
+                'invalid_value',
+                Status::cases(),
+                true,
+                Message::VALUE_NOT_IN_LIST->getMessage(
+                    'invalid_value',
+                    Status::ACTIVE->value,
+                    implode('\', \'', Enum::normalizeArray(Status::cases())),
+                ),
             ],
             'backed enum value in list' => [
                 'attribute',
@@ -279,7 +290,11 @@ final class ValidatorProvider
                 'a',
                 [],
                 true,
-                Message::VALUE_NOT_IN_LIST->getMessage('a', 'attribute', ''),
+                Message::VALUE_NOT_IN_LIST->getMessage(
+                    'a',
+                    'attribute',
+                    '',
+                ),
             ],
             'empty value-not-in-list' => [
                 'attribute',

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -55,7 +55,7 @@ final class ValidatorTest extends TestCase
      */
     #[DataProviderExternal(ValidatorProvider::class, 'oneOf')]
     public function testOneOfWithValidValues(
-        string $attribute,
+        string|UnitEnum $attribute,
         int|string|Stringable|UnitEnum|null $value,
         array $allowed,
         bool $exception,


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validator now accepts UnitEnum values for argument names and normalizes them for consistent, clear error messages.

* **Tests**
  * Added and expanded tests covering enum-based validation arguments, including backed-enum scenarios.

* **Chores**
  * Added a changelog entry for version 0.5.3 documenting the fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->