### PR TITLE
feat(helper): Add `normalizeAttribute()` method in `BaseAttributes` helper for normalization of attribute keys and values with support for encoding and JSON serialization, along with comprehensive tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ChangeLog
 
-## 0.5.4 Under development
+## 0.6.0 December 27, 2025
+
+- Enh #25: Add `normalizeAttribute()` method in `BaseAttributes` helper for normalization of attribute keys and values with support for encoding and JSON serialization, along with comprehensive tests (@terabytesoftw)
 
 ## 0.5.3 December 26, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0 December 27, 2025
 
-- Enh #25: Add `normalizeAttribute()` method in `BaseAttributes` helper for normalization of attribute keys and values with support for encoding and JSON serialization, along with comprehensive tests (@terabytesoftw)
+- Enh #25: Add `normalizeAttributes()` method in `BaseAttributes` helper for normalization of attribute keys and values with support for encoding and JSON serialization, along with comprehensive tests (@terabytesoftw)
 
 ## 0.5.3 December 26, 2025
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ echo Encode::content($user);
 
 #### Rendering HTML attributes
 
-Sorts attributes by priority, handles boolean values, and automatically encodes JSON for complex data.
+Use `Attributes::render()` to generate a safe, escaped HTML attribute string from an array. It automatically handles `class` arrays, `style` arrays, and `data-*` expansions.
 
 ```php
 <?php
@@ -135,6 +135,34 @@ use UIAwesome\Html\Helper\Attributes;
     ]
 ) ?>
 // class="btn btn-primary" id="submit-btn" disabled data-id="42" data-options='{"modal":true}' style='color: #fff; margin-top: 10px;'
+```
+
+#### Advanced: DOM & SVG Integration
+
+When working with `DOMDocument`, `SimpleXMLElement`, or other XML/SVG builders, you should not use pre-escaped strings to avoid "double escaping" (for example, `&amp;lt;`).
+
+Use `Attributes::normalizeAttributes()` with `encode: false` to get a flat array of raw values ready for insertion.
+
+```php
+use UIAwesome\Html\Helper\Attributes;
+
+$attributes = [
+    'title' => '<Safe Title>',
+    'data-config' => ['key' => '<val>']
+];
+
+// Get raw values (encode: false)
+$rawAttributes = Attributes::normalizeAttributes($attributes, encode: false);
+// [
+//    'title' => '<Safe Title>',
+//    'data-config' => '{"key":"<val>"}'
+// ]
+
+// Perfect for DOMDocument
+foreach ($rawAttributes as $name => $value) {
+    // DOMDocument handles the escaping automatically here
+    $domElement->setAttribute($name, (string)$value);
+}
 ```
 
 #### Managing CSS classes

--- a/README.md
+++ b/README.md
@@ -147,21 +147,23 @@ Use `Attributes::normalizeAttributes()` with `encode: false` to get a flat array
 use UIAwesome\Html\Helper\Attributes;
 
 $attributes = [
+    'class' => ['icon', ButtonType::PRIMARY],
+    'data-config' => ['key' => '<val>'],
     'title' => '<Safe Title>',
-    'data-config' => ['key' => '<val>']
 ];
 
 // Get raw values (encode: false)
 $rawAttributes = Attributes::normalizeAttributes($attributes, encode: false);
 // [
-//    'title' => '<Safe Title>',
+//    'class' => 'icon btn-primary',
 //    'data-config' => '{"key":"<val>"}'
+//    'title' => '<Safe Title>',
 // ]
 
 // Perfect for DOMDocument
 foreach ($rawAttributes as $name => $value) {
     // DOMDocument handles the escaping automatically here
-    $domElement->setAttribute($name, (string)$value);
+    $domElement->setAttribute($name, $value);
 }
 ```
 

--- a/src/Base/BaseAttributes.php
+++ b/src/Base/BaseAttributes.php
@@ -387,7 +387,7 @@ abstract class BaseAttributes
 
                 $result[$key] = match (gettype($v)) {
                     'array' => json_encode($v, $flags),
-                    'double', 'integer', 'string' => (string)$v,
+                    'double', 'integer', 'string' => (string) $v,
                     default => '',
                 };
             }

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -14,14 +14,15 @@ use UIAwesome\Html\Helper\Tests\Providers\AttributesProvider;
 /**
  * Test suite for {@see Attributes} helper functionality and behavior.
  *
- * Validates attribute rendering, ordering, and sanitization to ensure safe and deterministic HTML attributes generation
- * for element fragments and components.
+ * Validates attribute rendering, ordering, normalization, and sanitization to ensure safe and deterministic HTML
+ * attributes generation for element fragments and components.
  *
  * Ensures correct handling of ordering rules, empty and `null` values, enum-backed attributes, and
  * normalization/sanitization of malicious inputs to prevent XSS and attribute injection.
  *
  * Test coverage.
  * - Handling of empty and `null` values.
+ * - Proper normalization of attribute keys and values.
  * - Rendering order and deterministic attribute output.
  * - Sanitization of malicious or unexpected values.
  * - Support for enum-backed attribute values.
@@ -34,6 +35,25 @@ use UIAwesome\Html\Helper\Tests\Providers\AttributesProvider;
 #[Group('helper')]
 final class AttributesTest extends TestCase
 {
+    /**
+     * @phpstan-param mixed[] $attributes
+     * @phpstan-param mixed[] $expected
+     */
+    #[DataProviderExternal(AttributesProvider::class, 'normalizeAttributes')]
+    public function testNormalizeAttributes(array $attributes, array $expected, bool $encode = true): void
+    {
+        $normalizeAttribute = match ($encode) {
+            true => Attributes::normalizeAttributes($attributes),
+            false => Attributes::normalizeAttributes($attributes, false),
+        };
+
+        self::assertSame(
+            $expected,
+            $normalizeAttribute,
+            'Should normalize attributes returning the expected array structure.',
+        );
+    }
+
     #[DataProviderExternal(AttributesProvider::class, 'key')]
     public function testNormalizeKeyAttribute(mixed $key, string $prefix, string $expected): void
     {

--- a/tests/Providers/AttributesProvider.php
+++ b/tests/Providers/AttributesProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Helper\Tests\Providers;
 
-use stdClass;
 use Stringable;
 use UIAwesome\Html\Helper\Tests\Support\Stub\Enum\{ButtonSize, Columns, Key, Priority, Theme};
 use UnitEnum;

--- a/tests/Providers/AttributesProvider.php
+++ b/tests/Providers/AttributesProvider.php
@@ -368,6 +368,23 @@ final class AttributesProvider
                 ['title' => '&lt;script&gt;'],
                 true,
             ],
+            'enum' => [
+                ['value' => ButtonSize::LARGE],
+                ['value' => 'lg'],
+            ],
+            'enum inside class array' => [
+                [
+                    'class' => [
+                        'btn',
+                        ButtonSize::LARGE,
+                    ],
+                ],
+                ['class' => 'btn lg'],
+            ],
+            'enum inside data array' => [
+                ['data' => ['size' => ButtonSize::LARGE]],
+                ['data-size' => 'lg'],
+            ],
             'generic array attribute with encode false' => [
                 ['my-attr' => ['<tag>']],
                 ['my-attr' => '["<tag>"]'],

--- a/tests/Providers/AttributesProvider.php
+++ b/tests/Providers/AttributesProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Helper\Tests\Providers;
 
+use stdClass;
 use Stringable;
 use UIAwesome\Html\Helper\Tests\Support\Stub\Enum\{ButtonSize, Columns, Key, Priority, Theme};
 use UnitEnum;
@@ -334,6 +335,17 @@ final class AttributesProvider
                     ],
                 ],
                 ['class' => 'btn btn-primary'],
+            ],
+            'data attribute with unsupported types (boolean)' => [
+                [
+                    'data' => [
+                        'active' => true,
+                    ],
+                ],
+                [
+                    'data-active' => '',
+                ],
+                true,
             ],
             'data expansion' => [
                 [

--- a/tests/Providers/AttributesProvider.php
+++ b/tests/Providers/AttributesProvider.php
@@ -306,6 +306,119 @@ final class AttributesProvider
     }
 
     /**
+     * Provides datasets for attribute normalization.
+     *
+     * Each dataset returns the input attributes array, the expected normalized attributes array, and an optional encode
+     * flag (true/false) when relevant.
+     *
+     * @return array Test data for attribute normalization.
+     *
+     * @phpstan-return array<string, array{mixed[], mixed[], 2?: bool}>
+     */
+    public static function normalizeAttributes(): array
+    {
+        return [
+            'boolean false (removed)' => [
+                ['disabled' => false],
+                [],
+            ],
+            'boolean true (preserved as bool)' => [
+                ['checked' => true],
+                ['checked' => true],
+            ],
+            'class array flattened' => [
+                [
+                    'class' => [
+                        'btn',
+                        'btn-primary',
+                    ],
+                ],
+                ['class' => 'btn btn-primary'],
+            ],
+            'data expansion' => [
+                [
+                    'data' => [
+                        'id' => 1,
+                        'user' => 'admin',
+                    ],
+                ],
+                [
+                    'data-id' => '1',
+                    'data-user' => 'admin',
+                ],
+            ],
+            'encode false (Raw for SVG/DOM)' => [
+                ['title' => '<script>'],
+                ['title' => '<script>'],
+                false,
+            ],
+            'encode true (HTML entities)' => [
+                ['title' => '<script>'],
+                ['title' => '&lt;script&gt;'],
+                true,
+            ],
+            'generic array attribute with encode false' => [
+                ['my-attr' => ['<tag>']],
+                ['my-attr' => '["<tag>"]'],
+                false,
+            ],
+            'json flags in generic array with encode true' => [
+                ['data' => ['tags' => ['<tag>']]],
+                ['data-tags' => '["\u0026lt;tag\u0026gt;"]'],
+                true,
+            ],
+            'json flags in style array with encode true' => [
+                ['style' => ['--custom' => ['<val>']]],
+                ['style' => '--custom: ["\u0026lt;val\u0026gt;"];'],
+                true,
+            ],
+            'nested json with encode false' => [
+                [
+                    'data' => [
+                        'config' => [
+                            'key' => '<val>',
+                        ],
+                    ],
+                ],
+                ['data-config' => '{"key":"<val>"}'],
+                false,
+            ],
+            'simple string' => [
+                ['id' => 'my-id'],
+                ['id' => 'my-id'],
+            ],
+            'stringable encoding with encode true' => [
+                [
+                    'data' => [
+                        'val' => new class implements Stringable {
+                            public function __toString(): string
+                            {
+                                return '<x>';
+                            }
+                        },
+                    ],
+                ],
+                ['data-val' => '&lt;x&gt;'],
+                true,
+            ],
+            'style array flattened' => [
+                [
+                    'style' => [
+                        'color' => 'red',
+                        'background' => 'blue',
+                    ],
+                ],
+                ['style' => 'color: red; background: blue;'],
+            ],
+            'style property name encoding with encode true' => [
+                ['style' => ['<prop>' => 'val']],
+                ['style' => '&lt;prop&gt;: val;'],
+                true,
+            ],
+        ];
+    }
+
+    /**
      * Provides datasets for rendering tag attributes.
      *
      * Each dataset returns the expected rendered attributes string and an input attributes array. The cases cover


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attribute normalization support to produce consistent attribute data with optional encoding or raw output for DOM workflows.

* **Documentation**
  * Updated rendering guidance and added an "Advanced: DOM & SVG Integration" section illustrating raw vs. encoded attribute workflows and usage examples.

* **Tests**
  * Added test coverage for attribute normalization across many cases.

* **Chores**
  * Bumped changelog to 0.6.0 (December 27, 2025).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->