### PR TITLE
feat(validator): Add `offsetLike()` method in `BaseValidator` class for validating offset-like numbers with optional minimum and maximum constraints, along with related tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bug #31: Update configuration files and improve code structure for better maintainability and update related classes (@terabytesoftw)
 - Bug #32: Enhance documentation and improve clarity across multiple classes and methods (@terabytesoftw)
 - Bug #33: Enhance documentation tests and improve clarity across multiple test files (@terabytesoftw)
+- Enh #34: Add `offsetLike()` method in `BaseValidator` class for validating offset-like numbers with optional minimum and maximum constraints, along with related tests (@terabytesoftw)
 
 ## 0.6.3 January 3, 2026
 

--- a/src/Base/BaseValidator.php
+++ b/src/Base/BaseValidator.php
@@ -16,8 +16,11 @@ use function in_array;
 use function is_float;
 use function is_int;
 use function is_numeric;
+use function is_string;
 use function max;
+use function str_ends_with;
 use function stripos;
+use function substr;
 
 /**
  * Base class for validation utilities used by HTML helper components.
@@ -28,6 +31,7 @@ use function stripos;
  * Key features.
  * - Allow-list validation with UnitEnum normalization for consistent, strict comparisons.
  * - Integer-like validation for int and integer strings with optional range constraints.
+ * - Offset-like validation for percentage strings and ratio values.
  * - Positive-like number validation for int, float, and numeric strings with optional max constraint.
  * - Predictable behavior with explicit exceptions for invalid values.
  *
@@ -92,11 +96,53 @@ abstract class BaseValidator
             $value = (string) $value;
         }
 
-        if ($value[0] === '-' || $value[0] === '+' || ctype_digit($value) === false) {
+        if ($value[0] === '+') {
+            $value = substr($value, 1);
+        }
+
+        if ($value[0] === '-' || ctype_digit($value) === false) {
             return false;
         }
 
         return $value >= $min && ($max === null || $value <= $max);
+    }
+
+    /**
+     * Validates whether a value represents an offset value.
+     *
+     * If the value is a string that ends with `%`, the numeric part is validated as a non-negative number not greater
+     * than `100`. Otherwise, the value is validated as a non-negative number not greater than `1`.
+     *
+     * @param float|int|string|Stringable $value Value to validate.
+     *
+     * @return bool `true` if the value matches the accepted format and bounds, `false` otherwise.
+     *
+     * Usage example:
+     * ```php
+     * // ratio values (0-1)
+     * Validator::offsetLike(0.5);
+     * // `true`
+     *
+     * Validator::offsetLike('1.2');
+     * // `false`
+     *
+     * // percent values (0%-100%)
+     * Validator::offsetLike('50%');
+     * // `true`
+     *
+     * Validator::offsetLike('150%');
+     * // `false`
+     * ```
+     */
+    public static function offsetLike(float|int|string|Stringable $value): bool
+    {
+        if (is_string($value) && str_ends_with($value, '%')) {
+            $percentValue = substr($value, 0, -1);
+
+            return self::positiveLike($percentValue, max: 100);
+        }
+
+        return self::positiveLike($value, max: 1);
     }
 
     /**
@@ -246,7 +292,7 @@ abstract class BaseValidator
             return false;
         }
 
-        if ($value[0] === '-' || $value[0] === '+' || $value[0] === ' ' || $value[-1] === ' ') {
+        if ($value[0] === '-' || $value[0] === ' ' || $value[-1] === ' ') {
             return false;
         }
 

--- a/src/Base/BaseValidator.php
+++ b/src/Base/BaseValidator.php
@@ -88,6 +88,10 @@ abstract class BaseValidator
     {
         $min ??= 0;
 
+        if ($value === '') {
+            return false;
+        }
+
         if (is_int($value)) {
             return $value >= $min && ($max === null || $value <= $max);
         }

--- a/src/Base/BaseValidator.php
+++ b/src/Base/BaseValidator.php
@@ -100,7 +100,7 @@ abstract class BaseValidator
             $value = substr($value, 1);
         }
 
-        if ($value[0] === '-' || ctype_digit($value) === false) {
+        if ($value === '' ||$value[0] === '-' || ctype_digit($value) === false) {
             return false;
         }
 

--- a/src/Base/BaseValidator.php
+++ b/src/Base/BaseValidator.php
@@ -100,7 +100,7 @@ abstract class BaseValidator
             $value = substr($value, 1);
         }
 
-        if ($value === '' ||$value[0] === '-' || ctype_digit($value) === false) {
+        if ($value === '' || $value[0] === '-' || ctype_digit($value) === false) {
             return false;
         }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -13,6 +13,7 @@ namespace UIAwesome\Html\Helper;
  * - Validates allow-list membership via {@see Base\BaseValidator::oneOf()}.
  * - Validates integer-like values via {@see Base\BaseValidator::intLike()}.
  * - Validates non-negative numeric values via {@see Base\BaseValidator::positiveLike()}.
+ * - Validates offset values via {@see Base\BaseValidator::offsetLike()}.
  *
  * Usage example:
  * ```php

--- a/tests/Providers/ValidatorProvider.php
+++ b/tests/Providers/ValidatorProvider.php
@@ -13,15 +13,10 @@ use UnitEnum;
 /**
  * Data provider for {@see \UIAwesome\Html\Helper\Tests\ValidatorTest} test cases.
  *
- * Supplies focused datasets used by validation helpers for integer-like checks and allowed-value lists.
+ * Supplies datasets for the {@see \UIAwesome\Html\Helper\Validator} validation helpers.
  *
- * The cases cover numeric string handling, boundary conditions, enum comparisons, mixed-type lists, and failure message
- * generation for invalid inputs.
- *
- * Key features.
- * - Provide comprehensive `oneOf` datasets including backed enums, unit enums and mixed-type lists.
- * - Return tuples describing input, constraints, expected validity and expected message text.
- * - Validate integer-like string and numeric inputs with `min`/`max` boundaries.
+ * The cases cover numeric string handling, boundary conditions, enum normalization, mixed-type lists, and failure
+ * message generation for invalid inputs.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -192,8 +187,8 @@ final class ValidatorProvider
                 '+1',
                 0,
                 null,
-                false,
-                'Should be invalid value.',
+                true,
+                'Should be valid value.',
             ],
             'string numeric within range' => [
                 '3',
@@ -234,6 +229,65 @@ final class ValidatorProvider
                 10,
                 true,
                 'Should be valid value.',
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<string, array{int|float|string|Stringable, bool, string}>
+     */
+    public static function offsetLike(): array
+    {
+        return [
+            'float above max invalid' => [
+                1.1,
+                false,
+                'Should be invalid offset value.',
+            ],
+            'float middle valid' => [
+                0.5,
+                true,
+                'Should be valid offset value.',
+            ],
+            'float negative invalid' => [
+                -0.1,
+                false,
+                'Should be invalid offset value.',
+            ],
+            'integer lower bound valid' => [
+                0,
+                true,
+                'Should be valid offset value.',
+            ],
+            'integer upper bound valid' => [
+                1,
+                true,
+                'Should be valid offset value.',
+            ],
+            'string with percentage above max invalid' => [
+                '101%',
+                false,
+                'Should be invalid offset value.',
+            ],
+            'string with percentage negative invalid' => [
+                '-1%',
+                false,
+                'Should be invalid offset value.',
+            ],
+            'string with percentage plus sign valid' => [
+                '+10%',
+                true,
+                'Should be valid offset value.',
+            ],
+            'string with percentage upper bound valid' => [
+                '100%',
+                true,
+                'Should be valid offset value.',
+            ],
+            'string with percentage' => [
+                '5%',
+                true,
+                'Should be valid offset value.',
             ],
         ];
     }
@@ -738,15 +792,15 @@ final class ValidatorProvider
                 '+1.5',
                 null,
                 null,
-                false,
-                'Should be invalid value.',
+                true,
+                'Should be valid value.',
             ],
             'string with plus sign invalid' => [
                 '+1',
                 null,
                 null,
-                false,
-                'Should be invalid value.',
+                true,
+                'Should be valid value.',
             ],
             'string with trailing space invalid' => [
                 '1.5 ',

--- a/tests/Providers/ValidatorProvider.php
+++ b/tests/Providers/ValidatorProvider.php
@@ -13,10 +13,7 @@ use UnitEnum;
 /**
  * Data provider for {@see \UIAwesome\Html\Helper\Tests\ValidatorTest} test cases.
  *
- * Supplies datasets for the {@see \UIAwesome\Html\Helper\Validator} validation helpers.
- *
- * The cases cover numeric string handling, boundary conditions, enum normalization, mixed-type lists, and failure
- * message generation for invalid inputs.
+ * Provides representative input/output pairs for validator helper methods.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -119,6 +116,13 @@ final class ValidatorProvider
                 10,
                 true,
                 'Should be valid value.',
+            ],
+            'string empty invalid' => [
+                '',
+                0,
+                null,
+                false,
+                'Should be invalid value.',
             ],
             'string float' => [
                 '3.5',

--- a/tests/Providers/ValidatorProvider.php
+++ b/tests/Providers/ValidatorProvider.php
@@ -275,10 +275,25 @@ final class ValidatorProvider
                 true,
                 'Should be valid offset value.',
             ],
+            'string decimal above max invalid' => [
+                '1.1',
+                false,
+                'Should be invalid offset value.',
+            ],
+            'string decimal within range' => [
+                '0.5',
+                true,
+                'Should be valid offset value.',
+            ],
             'string with percentage above max invalid' => [
                 '101%',
                 false,
                 'Should be invalid offset value.',
+            ],
+            'string with percentage lower bound valid' => [
+                '0%',
+                true,
+                'Should be valid offset value.',
             ],
             'string with percentage negative invalid' => [
                 '-1%',

--- a/tests/Providers/ValidatorProvider.php
+++ b/tests/Providers/ValidatorProvider.php
@@ -197,6 +197,13 @@ final class ValidatorProvider
                 true,
                 'Should be valid value.',
             ],
+            'string only plus sign' => [
+                '+',
+                0,
+                null,
+                false,
+                'Should be invalid value.',
+            ],
             'string scientific notation' => [
                 '1e3',
                 0,

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -21,10 +21,10 @@ use UnitEnum;
  * allowed.
  *
  * Test coverage.
- * - Detection of integer-like values with optional `min`/`max` constraints.
- * - Detection of offset values for ratio values and percentage strings.
- * - Validation against allowed value lists and exception behavior.
- * - Validation of non-negative numeric values with optional `min`/`max` constraints.
+ * - {@see Validator::intLike()} validation with optional `min`/`max` constraints.
+ * - {@see Validator::offsetLike()} validation for ratio values and percentage strings.
+ * - {@see Validator::oneOf()} validation for allow-list membership and exception behavior.
+ * - {@see Validator::positiveLike()} validation with optional `min`/`max` constraints.
  *
  * {@see ValidatorProvider} for data-driven test cases and edge conditions.
  *

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -13,20 +13,21 @@ use UIAwesome\Html\Helper\Validator;
 use UnitEnum;
 
 /**
- * Unit tests for {@see Validator} helper functionality and behavior.
+ * Unit tests for {@see Validator} helper validation behavior.
  *
- * Validates the {@see Validator} helpers using data providers for representative values and boundary conditions.
- *
- * Ensures correct handling of numeric strings, bounds checks, and explicit error reporting for values that are not
- * allowed.
+ * Verifies boolean validation results and exception messages for representative scalar, `Stringable`, and enum-backed
+ * inputs across the {@see Validator} helper methods.
  *
  * Test coverage.
- * - {@see Validator::intLike()} validation with optional `min`/`max` constraints.
- * - {@see Validator::offsetLike()} validation for ratio values and percentage strings.
- * - {@see Validator::oneOf()} validation for allow-list membership and exception behavior.
- * - {@see Validator::positiveLike()} validation with optional `min`/`max` constraints.
+ * - Accepts int-like values as `int`, numeric `string`, and `Stringable` with optional `min`/`max` constraints.
+ * - Accepts positive-like values as `int`, `float`, numeric `string`, and `Stringable` with optional `min`/`max`
+ *   constraints.
+ * - Validates offset-like values for ratios and percentage strings within the expected bounds.
+ * - Validates one-of allow-list membership for scalar and enum values, throwing {@see InvalidArgumentException} with
+ *   the expected message when configured.
  *
- * {@see ValidatorProvider} for data-driven test cases and edge conditions.
+ * {@see Validator} for implementation details.
+ * {@see ValidatorProvider} for test case data providers.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -15,16 +15,16 @@ use UnitEnum;
 /**
  * Unit tests for {@see Validator} helper functionality and behavior.
  *
- * Validates common validation helpers such as integer-like detection and allowed-value checks used across form handling
- * and attribute validation routines.
+ * Validates the {@see Validator} helpers using data providers for representative values and boundary conditions.
  *
- * Ensures correct handling of numeric strings, boundary checks, and explicit error reporting for disallowed values or
- * invalid arguments.
+ * Ensures correct handling of numeric strings, bounds checks, and explicit error reporting for values that are not
+ * allowed.
  *
  * Test coverage.
- * - Detection of integer-like values with optional min/max constraints.
- * - Detection of positive-like number values greater than zero with optional max constraint.
+ * - Detection of integer-like values with optional `min`/`max` constraints.
+ * - Detection of offset values for ratio values and percentage strings.
  * - Validation against allowed value lists and exception behavior.
+ * - Validation of non-negative numeric values with optional `min`/`max` constraints.
  *
  * {@see ValidatorProvider} for data-driven test cases and edge conditions.
  *
@@ -45,6 +45,19 @@ final class ValidatorTest extends TestCase
         self::assertSame(
             $expected,
             Validator::intLike($value, $min, $max),
+            $message,
+        );
+    }
+
+    #[DataProviderExternal(ValidatorProvider::class, 'offsetLike')]
+    public function testOffsetLike(
+        int|float|string|Stringable $value,
+        bool $expected,
+        string $message,
+    ): void {
+        self::assertSame(
+            $expected,
+            Validator::offsetLike($value),
             $message,
         );
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offset-like validation supporting percentage strings (0–100%) and numeric offsets (0–1).

* **Improvements**
  * Refined integer- and positive-like validation to better handle an optional leading '+' and stricter bounds.

* **Tests**
  * Added data-driven tests and provider coverage for offset-like scenarios.

* **Documentation**
  * Updated changelog and validator docs to describe the new offset-like validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->