### PR TITLE
fix(docs): Enhance documentation for `Message` enum to clarify error message templates and formatting usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Bug #36: Move directory `tests\Providers` to `tests\Support\Provider` for better organization (@terabytesoftw)
 - Enh #37: Add usage examples for HTML helper methods, including attribute normalization and SVG offset validation (@terabytesoftw)
 - Bug #38: Update testing documentation for clarity and organization (@terabytesoftw)
-- Enh #39: Add `php-forge/support` as a development dependency and update related test classes (@terabytesoftw)
+- Enh #39: Add development guide for workflows and maintenance tasks (@terabytesoftw)
+- Enh #40: Add `php-forge/support` as a development dependency and update related test classes (@terabytesoftw)
+- Bug #41: Enhance documentation for `Message` enum to clarify error message templates and formatting usage (@terabytesoftw)
 
 ## 0.6.4 January 18, 2026
 
@@ -14,7 +16,6 @@
 - Bug #33: Enhance documentation tests and improve clarity across multiple test files (@terabytesoftw)
 - Enh #34: Add `offsetLike()` method in `BaseValidator` class for validating offset-like numbers with optional minimum and maximum constraints, along with related tests (@terabytesoftw)
 - Bug #35: Update documentation in test files and providers for clarity and consistency (@terabytesoftw)
-- Enh #36: Add development guide for workflows and maintenance tasks (@terabytesoftw)
 
 ## 0.6.3 January 3, 2026
 

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -7,24 +7,24 @@ namespace UIAwesome\Html\Helper\Exception;
 use function sprintf;
 
 /**
- * Represents standardized error messages.
+ * Represents error message templates.
  *
  * This enum defines formatted error messages for various error conditions that may occur during operations such as
- * value validation.
+ * parsing properties, validating input values, and handling form models.
  *
- * It provides a consistent and standardized way to present error messages across the system.
+ * It provides message templates that can be formatted at call sites.
  *
  * Each case represents a specific type of error, with a message template that can be populated with dynamic values
  * using the {@see Message::getMessage()} method.
  *
- * This centralized approach improves the consistency of error messages.
+ * Each message template can be formatted with arguments.
  *
  * Key features.
- * - Centralization of an error text for easier maintenance.
- * - Consistent error handling across the system.
- * - Integration with specific exception classes.
- * - Message formatting with dynamic parameters.
- * - Standardized error messages for common and utility cases.
+ * - Can be used by exception call sites that need formatted messages.
+ * - Defines message templates as enum cases.
+ * - Formats templates with `sprintf()` via {@see Message::getMessage()}.
+ * - Supports message formatting with dynamic parameters.
+ * - Uses the enum case `value` as the template string.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -91,11 +91,9 @@ enum Message: string
     /**
      * Returns the formatted message string for the error case.
      *
-     * Retrieves and formats the error message string by interpolating the provided arguments.
+     * @param int|string ...$argument Values to insert into the message template.
      *
-     * @param int|string ...$argument Dynamic arguments to insert into the message.
-     *
-     * @return string Error message with interpolated arguments.
+     * @return string Formatted error message with interpolated arguments.
      *
      * Usage example:
      * ```php


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved error documentation to clarify message templating and formatting approach.
  * Updated changelog entries for better organization and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->