### PR TITLE
feat(helper): Simplify `AttributeBag` to generic `set()` and `setMany()` operations (removing `add()`), while keeping `Attributes` responsible for `aria`, `data`, and `on` expansion during rendering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # ChangeLog
 
-## 0.6.10 Under development
+## 0.7.0 Under development
 
-- Enh #49: Simplify `AttributeBag` to generic `set()` and `setMany()` operations while keeping `Attributes` responsible for `aria`, `data`, and `on` expansion during rendering (@terabytesoftw)
+- Enh #49: Simplify `AttributeBag` to generic `set()` and `setMany()` operations (removing `add()`), while keeping `Attributes` responsible for `aria`, `data`, and `on` expansion during rendering (@terabytesoftw)
 
 ## 0.6.9 February 14, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.6.10 Under development
 
+- Enh #49: Simplify `AttributeBag` to generic `set()` and `setMany()` operations while keeping `Attributes` responsible for `aria`, `data`, and `on` expansion during rendering (@terabytesoftw)
+
 ## 0.6.9 February 14, 2026
 
 - Enh #46: Add helper `AttributeBag` class to centralize `add()`, `get()`, `merge()`, `remove()`, and `set()` operations with unit tests (@terabytesoftw)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ use UIAwesome\Html\Helper\Attributes;
 
 #### Attribute bag operations
 
-Use `AttributeBag` to query and mutate an attribute array in-place, with key normalization and optional boolean string conversion.
+Use `AttributeBag` to query and mutate an attribute array in-place with a minimal API (`get()`, `merge()`,
+`remove()`, `set()`, `setMany()`).
 
 ```php
 <?php
@@ -152,9 +153,9 @@ use UIAwesome\Html\Helper\AttributeBag;
 
 $attributes = ['id' => 'submit'];
 
-// add or remove values
-AttributeBag::add($attributes, 'disabled', true);
-AttributeBag::add($attributes, 'id', null);
+// set or remove values
+AttributeBag::set($attributes, 'disabled', true);
+AttributeBag::set($attributes, 'id', null);
 
 // read with fallback default
 $type = AttributeBag::get($attributes, 'type', 'button');
@@ -162,9 +163,17 @@ $type = AttributeBag::get($attributes, 'type', 'button');
 // merge arrays (later values override)
 AttributeBag::merge($attributes, ['class' => ['btn', 'btn-primary'], 'type' => 'submit']);
 
-// normalize keys, resolve closures, and optionally convert booleans to `'true'`/`'false'`
-AttributeBag::set($attributes, 'label', static fn(): string => 'Save', 'aria-');
-AttributeBag::set($attributes, 'hidden', false, 'aria-', true);
+// set one key (raw value)
+AttributeBag::set($attributes, 'aria-label', 'Save');
+
+// set many keys at once (useful for trait-driven prefixed attributes)
+AttributeBag::setMany(
+    $attributes,
+    [
+        'data-toggle' => 'modal',
+        'onclick' => 'handleClick()',
+    ],
+);
 
 // remove keys
 AttributeBag::remove($attributes, 'disabled');

--- a/README.md
+++ b/README.md
@@ -153,15 +153,18 @@ use UIAwesome\Html\Helper\AttributeBag;
 
 $attributes = ['id' => 'submit'];
 
+// merge arrays (later values override)
+AttributeBag::merge($attributes, ['class' => ['btn', 'btn-primary'], 'type' => 'submit']);
+
+// get with fallback default
+$type = AttributeBag::get($attributes, 'type', 'button');
+
+// remove keys
+AttributeBag::remove($attributes, 'disabled');
+
 // set or remove values
 AttributeBag::set($attributes, 'disabled', true);
 AttributeBag::set($attributes, 'id', null);
-
-// read with fallback default
-$type = AttributeBag::get($attributes, 'type', 'button');
-
-// merge arrays (later values override)
-AttributeBag::merge($attributes, ['class' => ['btn', 'btn-primary'], 'type' => 'submit']);
 
 // set one key (raw value)
 AttributeBag::set($attributes, 'aria-label', 'Save');
@@ -174,9 +177,6 @@ AttributeBag::setMany(
         'onclick' => 'handleClick()',
     ],
 );
-
-// remove keys
-AttributeBag::remove($attributes, 'disabled');
 ```
 
 #### Advanced: DOM & SVG Integration

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -47,7 +47,7 @@
             <div class="container">
                 <div class="alert-box">
                     <p class="alert-title"><strong>Attribute Bag</strong></p>
-                    <p class="alert-content">In-place <code>add()</code>, <code>get()</code>, <code>merge()</code>, <code>remove()</code>, <code>set()</code> operations for attribute arrays</p>
+                    <p class="alert-content">In-place <code>get()</code>, <code>merge()</code>, <code>remove()</code>, <code>set()</code>, <code>setMany()</code> operations for attribute arrays</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Enum Integration</strong></p>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -44,7 +44,7 @@
             <div class="container">
                 <div class="alert-box">
                     <p class="alert-title"><strong>Attribute Bag</strong></p>
-                    <p class="alert-content">In-place <code>add()</code>, <code>get()</code>, <code>merge()</code>, <code>remove()</code>, <code>set()</code> operations for attribute arrays</p>
+                    <p class="alert-content">In-place <code>get()</code>, <code>merge()</code>, <code>remove()</code>, <code>set()</code>, <code>setMany()</code> operations for attribute arrays</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Enum Integration</strong></p>

--- a/src/AttributeBag.php
+++ b/src/AttributeBag.php
@@ -11,7 +11,7 @@ use UIAwesome\Html\Helper\Base\BaseAttributeBag;
  *
  * Usage example:
  * ```php
- * \UIAwesome\Html\Helper\AttributeBag::add($attributes, 'disabled', true);
+ * \UIAwesome\Html\Helper\AttributeBag::set($attributes, 'disabled', true);
  * \UIAwesome\Html\Helper\AttributeBag::get($attributes, 'id');
  * ```
  *

--- a/src/Base/BaseAttributeBag.php
+++ b/src/Base/BaseAttributeBag.php
@@ -21,38 +21,6 @@ use function is_string;
 abstract class BaseAttributeBag
 {
     /**
-     * Adds or removes an attribute in the given attribute bag.
-     *
-     * If the provided value is `null`, the normalized key is removed from the bag.
-     *
-     * Usage example:
-     * ```php
-     * \UIAwesome\Html\Helper\AttributeBag::add($attributes, 'disabled', true);
-     * \UIAwesome\Html\Helper\AttributeBag::add($attributes, 'id', null);
-     * ```
-     *
-     * @param array $attributes Attribute bag to update in place.
-     * @param string|UnitEnum $key Attribute key.
-     * @param mixed $value Attribute value.
-     *
-     * @throws InvalidArgumentException if normalized key is not a non-empty `string`.
-     *
-     * @phpstan-param mixed[] $attributes
-     */
-    public static function add(array &$attributes, string|UnitEnum $key, mixed $value): void
-    {
-        $normalizedKey = self::normalizeKey($key);
-
-        if ($value === null) {
-            unset($attributes[$normalizedKey]);
-
-            return;
-        }
-
-        $attributes[$normalizedKey] = $value;
-    }
-
-    /**
      * Returns an attribute value by key.
      *
      * Usage example:
@@ -213,7 +181,7 @@ abstract class BaseAttributeBag
      */
     private static function prepareManyKey(mixed $key): string
     {
-        if (is_string($key)) {
+        if (is_string($key) && $key !== '') {
             return $key;
         }
 

--- a/src/Base/BaseAttributeBag.php
+++ b/src/Base/BaseAttributeBag.php
@@ -221,5 +221,4 @@ abstract class BaseAttributeBag
             Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
         );
     }
-
 }

--- a/src/Base/BaseAttributeBag.php
+++ b/src/Base/BaseAttributeBag.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Helper\Base;
 
-use Closure;
 use InvalidArgumentException;
-use Stringable;
-use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Enum;
 use UIAwesome\Html\Helper\Exception\Message;
 use UnitEnum;
 
 use function array_key_exists;
-use function is_bool;
 use function is_string;
 
 /**
@@ -135,50 +132,52 @@ abstract class BaseAttributeBag
     }
 
     /**
-     * Normalizes and sets an attribute key/value pair.
-     *
-     * Resolves closure values, optionally converts boolean values to `'true'`/`'false'`, and removes the key when the
-     * resolved value is `null`.
+     * Sets a plain attribute key/value pair.
      *
      * Usage example:
      * ```php
      * $attributes = [];
-     * \UIAwesome\Html\Helper\AttributeBag::set($attributes, 'disabled', true, '', true);
+     * \UIAwesome\Html\Helper\AttributeBag::set($attributes, 'disabled', true);
      * \UIAwesome\Html\Helper\AttributeBag::set($attributes, 'id', static fn () => 'submit');
      * ```
      *
      * @param array $attributes Attribute bag to update in place.
      * @param string|UnitEnum $key Attribute key to normalize.
-     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Attribute value.
-     * @param string $prefix Prefix applied via {@see Attributes::normalizeKey()}.
-     * @param bool $boolToString Whether boolean values should be cast to `'true'`/`'false'`.
+     * @param mixed $value Attribute value.
      *
      * @throws InvalidArgumentException if key normalization fails.
      *
      * @phpstan-param mixed[] $attributes
-     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
      */
-    public static function set(
-        array &$attributes,
-        string|UnitEnum $key,
-        bool|Closure|float|int|string|Stringable|UnitEnum|null $value,
-        string $prefix = '',
-        bool $boolToString = false,
-    ): void {
-        $normalizedKey = Attributes::normalizeKey($key, $prefix);
-        $resolvedValue = $value instanceof Closure ? $value() : $value;
+    public static function set(array &$attributes, string|UnitEnum $key, mixed $value): void
+    {
+        $normalizedKey = self::normalizeKey($key);
 
-        if ($boolToString && is_bool($resolvedValue)) {
-            $resolvedValue = $resolvedValue ? 'true' : 'false';
-        }
-
-        if ($resolvedValue === null) {
+        if ($value === null) {
             unset($attributes[$normalizedKey]);
 
             return;
         }
 
-        $attributes[$normalizedKey] = $resolvedValue;
+        $attributes[$normalizedKey] = $value;
+    }
+
+    /**
+     * Sets multiple plain attributes.
+     *
+     * @param array $attributes Attribute bag to update in place.
+     * @param array $values Values to set.
+     *
+     * @throws InvalidArgumentException if any key normalization fails.
+     *
+     * @phpstan-param mixed[] $attributes
+     * @phpstan-param mixed[] $values
+     */
+    public static function setMany(array &$attributes, array $values): void
+    {
+        foreach ($values as $key => $value) {
+            self::set($attributes, self::prepareManyKey($key), $value);
+        }
     }
 
     /**
@@ -202,4 +201,25 @@ abstract class BaseAttributeBag
 
         return $normalizedKey;
     }
+
+    /**
+     * Prepares an array key for `*Many()` methods.
+     *
+     * @param mixed $key Array key.
+     *
+     * @throws InvalidArgumentException when key is not a non-empty string.
+     *
+     * @return string Prepared key.
+     */
+    private static function prepareManyKey(mixed $key): string
+    {
+        if (is_string($key)) {
+            return $key;
+        }
+
+        throw new InvalidArgumentException(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+        );
+    }
+
 }

--- a/src/Base/BaseAttributes.php
+++ b/src/Base/BaseAttributes.php
@@ -20,7 +20,6 @@ use function json_encode;
 use function preg_match;
 use function rtrim;
 use function str_starts_with;
-use function strlen;
 use function uksort;
 
 /**

--- a/src/Base/BaseAttributes.php
+++ b/src/Base/BaseAttributes.php
@@ -262,14 +262,16 @@ abstract class BaseAttributes
         $flags = $encode ? self::JSON_FLAGS : self::JSON_FLAGS_RAW;
 
         foreach ($values as $n => $v) {
-            if ($v !== null && is_string($n) && $n !== '') {
+            if ($v !== null && is_string($n) && $n !== '' && self::isValidAttributeName($n)) {
                 $key = str_starts_with($n, 'on') ? $n : "on{$n}";
 
-                $result[$key] = match (gettype($v)) {
-                    'array' => json_encode($v, $flags),
-                    'double', 'integer', 'string' => (string) $v,
-                    default => '',
-                };
+                if (self::isValidAttributeName($key)) {
+                    $result[$key] = match (gettype($v)) {
+                        'array' => json_encode($v, $flags),
+                        'double', 'integer', 'string' => (string) $v,
+                        default => '',
+                    };
+                }
             }
         }
 

--- a/src/Base/BaseAttributes.php
+++ b/src/Base/BaseAttributes.php
@@ -208,6 +208,75 @@ abstract class BaseAttributes
     }
 
     /**
+     * Expands dashed namespace attributes (`aria-*`, `data-*`, etc.) into a flat associative array.
+     *
+     * @param string $name Attribute prefix (for example, `data`, `aria`).
+     * @param array $values Associative array of attribute names and values.
+     * @param bool $encode Whether to HTML-encode string values.
+     *
+     * @return array Associative array of expanded attribute key-value pairs.
+     *
+     * @phpstan-param mixed[] $values
+     * @phpstan-return array<string, string>
+     */
+    private static function expandDashedAttributes(string $name, array $values, bool $encode): array
+    {
+        $result = [];
+        $flags = $encode ? self::JSON_FLAGS : self::JSON_FLAGS_RAW;
+
+        foreach ($values as $n => $v) {
+            if ($v === null) {
+                continue;
+            }
+
+            if (is_string($n) && self::isValidAttributeName($n)) {
+                $key = "{$name}-{$n}";
+
+                $result[$key] = match (gettype($v)) {
+                    'array' => json_encode($v, $flags),
+                    'double', 'integer', 'string' => (string) $v,
+                    default => '',
+                };
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Expands canonical event attributes into `on*` key-value pairs.
+     *
+     * Keys that already start with `on` are preserved. Other keys are prefixed with `on`.
+     *
+     * @param array $values Associative array of event names and values.
+     * @param bool $encode Whether to HTML-encode string values.
+     *
+     * @return array Associative array of expanded event attributes.
+     *
+     * @phpstan-param mixed[] $values
+     * @phpstan-return array<string, string>
+     */
+    private static function expandEventAttributes(array $values, bool $encode): array
+    {
+        $result = [];
+        $flags = $encode ? self::JSON_FLAGS : self::JSON_FLAGS_RAW;
+
+        foreach ($values as $n => $v) {
+            if ($v !== null && is_string($n) && $n !== '') {
+                $key = str_starts_with($n, 'on') ? $n : "on{$n}";
+
+                $result[$key] = match (gettype($v)) {
+                    'array' => json_encode($v, $flags),
+                    'double', 'integer', 'string' => (string) $v,
+                    default => '',
+                };
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Validates that an attribute name follows HTML naming rules.
      *
      * Ensures that the provided attribute name is non-empty and matches the allowed HTML attribute naming pattern.
@@ -282,75 +351,6 @@ abstract class BaseAttributes
     private static function normalizeClassValue(array $values): string
     {
         return $values === [] ? '' : implode(' ', $values);
-    }
-
-    /**
-     * Expands dashed namespace attributes (`aria-*`, `data-*`, etc.) into a flat associative array.
-     *
-     * @param string $name Attribute prefix (for example, `data`, `aria`).
-     * @param array $values Associative array of attribute names and values.
-     * @param bool $encode Whether to HTML-encode string values.
-     *
-     * @return array Associative array of expanded attribute key-value pairs.
-     *
-     * @phpstan-param mixed[] $values
-     * @phpstan-return array<string, string>
-     */
-    private static function expandDashedAttributes(string $name, array $values, bool $encode): array
-    {
-        $result = [];
-        $flags = $encode ? self::JSON_FLAGS : self::JSON_FLAGS_RAW;
-
-        foreach ($values as $n => $v) {
-            if ($v === null) {
-                continue;
-            }
-
-            if (is_string($n) && self::isValidAttributeName($n)) {
-                $key = "{$name}-{$n}";
-
-                $result[$key] = match (gettype($v)) {
-                    'array' => json_encode($v, $flags),
-                    'double', 'integer', 'string' => (string) $v,
-                    default => '',
-                };
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Expands canonical event attributes into `on*` key-value pairs.
-     *
-     * Keys that already start with `on` are preserved. Other keys are prefixed with `on`.
-     *
-     * @param array $values Associative array of event names and values.
-     * @param bool $encode Whether to HTML-encode string values.
-     *
-     * @return array Associative array of expanded event attributes.
-     *
-     * @phpstan-param mixed[] $values
-     * @phpstan-return array<string, string>
-     */
-    private static function expandEventAttributes(array $values, bool $encode): array
-    {
-        $result = [];
-        $flags = $encode ? self::JSON_FLAGS : self::JSON_FLAGS_RAW;
-
-        foreach ($values as $n => $v) {
-            if ($v !== null && is_string($n) && $n !== '') {
-                $key = str_starts_with($n, 'on') ? $n : "on{$n}";
-
-                $result[$key] = match (gettype($v)) {
-                    'array' => json_encode($v, $flags),
-                    'double', 'integer', 'string' => (string) $v,
-                    default => '',
-                };
-            }
-        }
-
-        return $result;
     }
 
     /**

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -16,12 +16,10 @@ use UnitEnum;
  * Unit tests for the {@see AttributeBag} helper.
  *
  * Test coverage.
- * - Adds attributes and removes keys when values are `null`.
  * - Merges attribute arrays and overrides existing keys.
  * - Removes attributes for valid keys.
- * - Sets plain attributes with raw values.
  * - Sets multiple attributes through dedicated `*Many()` APIs.
- * - Throws exceptions for invalid keys in `add()`.
+ * - Sets plain attributes with raw values.
  * - Throws exceptions for invalid keys in `get()`.
  * - Throws exceptions for invalid keys in `remove()`.
  * - Throws exceptions for invalid keys in `set()` and `*Many()` APIs.
@@ -35,23 +33,6 @@ use UnitEnum;
 #[Group('helper')]
 final class AttributeBagTest extends TestCase
 {
-    /**
-     * @phpstan-param mixed[] $attributes
-     * @phpstan-param string|UnitEnum $key
-     * @phpstan-param mixed[] $expected
-     */
-    #[DataProviderExternal(AttributeBagProvider::class, 'add')]
-    public function testAdd(array $attributes, string|UnitEnum $key, mixed $value, array $expected): void
-    {
-        AttributeBag::add($attributes, $key, $value);
-
-        self::assertSame(
-            $expected,
-            $attributes,
-            'Should add values and remove key when value is `null`.',
-        );
-    }
-
     /**
      * @phpstan-param mixed[] $attributes
      * @phpstan-param string|UnitEnum $key
@@ -136,17 +117,6 @@ final class AttributeBagTest extends TestCase
             $attributes,
             'Should set many plain attributes and remove keys with `null` values.',
         );
-    }
-
-    #[DataProviderExternal(AttributeBagProvider::class, 'invalidKey')]
-    public function testThrowInvalidArgumentExceptionWhenAdd(string|UnitEnum $key): void
-    {
-        $attributes = ['id' => 'submit'];
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage());
-
-        AttributeBag::add($attributes, $key, 'value');
     }
 
     #[DataProviderExternal(AttributeBagProvider::class, 'invalidKey')]

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -115,7 +115,7 @@ final class AttributeBagTest extends TestCase
         self::assertSame(
             $expected,
             $attributes,
-            'Should set many plain attributes and remove keys with `null` values.',
+            "Should set many plain attributes and remove keys with 'null' values.",
         );
     }
 

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Helper\Tests;
 
-use Closure;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use Stringable;
 use UIAwesome\Html\Helper\AttributeBag;
 use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Helper\Tests\Provider\AttributeBagProvider;
@@ -21,11 +19,12 @@ use UnitEnum;
  * - Adds attributes and removes keys when values are `null`.
  * - Merges attribute arrays and overrides existing keys.
  * - Removes attributes for valid keys.
- * - Sets normalized keys, resolves closures, and applies `bool` to `true`, and `false` conversion.
+ * - Sets plain attributes with raw values.
+ * - Sets multiple attributes through dedicated `*Many()` APIs.
  * - Throws exceptions for invalid keys in `add()`.
  * - Throws exceptions for invalid keys in `get()`.
  * - Throws exceptions for invalid keys in `remove()`.
- * - Throws exceptions for invalid keys in `set()`.
+ * - Throws exceptions for invalid keys in `set()` and `*Many()` APIs.
  * - Verifies `get()` returns existing values or fallback defaults.
  *
  * {@see AttributeBagProvider} for test case data providers.
@@ -103,27 +102,39 @@ final class AttributeBagTest extends TestCase
 
     /**
      * @phpstan-param mixed[] $attributes
-     * @phpstan-param bool|float|int|string|Closure(): mixed|Stringable|UnitEnum|null $value
+     * @phpstan-param string|UnitEnum $key
      * @phpstan-param mixed[] $expected
      */
     #[DataProviderExternal(AttributeBagProvider::class, 'set')]
     public function testSet(
         array $attributes,
         string|UnitEnum $key,
-        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
-        string $prefix,
-        bool $boolToString,
+        mixed $value,
         array $expected,
     ): void {
-        match ($boolToString) {
-            true => AttributeBag::set($attributes, $key, $value, $prefix, true),
-            false => AttributeBag::set($attributes, $key, $value, $prefix),
-        };
+        AttributeBag::set($attributes, $key, $value);
 
         self::assertSame(
             $expected,
             $attributes,
-            'Should set values with normalized key and expected value transformation.',
+            'Should set plain raw values with key normalization.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     * @phpstan-param mixed[] $values
+     * @phpstan-param mixed[] $expected
+     */
+    #[DataProviderExternal(AttributeBagProvider::class, 'setMany')]
+    public function testSetMany(array $attributes, array $values, array $expected): void
+    {
+        AttributeBag::setMany($attributes, $values);
+
+        self::assertSame(
+            $expected,
+            $attributes,
+            'Should set many plain attributes and remove keys with `null` values.',
         );
     }
 
@@ -169,5 +180,19 @@ final class AttributeBagTest extends TestCase
         $this->expectExceptionMessage(Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage());
 
         AttributeBag::set($attributes, $key, 'value');
+    }
+
+    /**
+     * @phpstan-param mixed[] $values
+     */
+    #[DataProviderExternal(AttributeBagProvider::class, 'invalidManyKey')]
+    public function testThrowInvalidArgumentExceptionWhenSetMany(array $values, string $message): void
+    {
+        $attributes = ['id' => 'submit'];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        AttributeBag::setMany($attributes, $values);
     }
 }

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -65,7 +65,6 @@ final class AttributeBagProvider
                 [1 => 'value'],
                 Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
             ],
-
         ];
     }
 

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Helper\Tests\Provider;
 
 use PHPForge\Support\Stub\BackedInteger;
+use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Helper\Tests\Support\Key;
 use UnitEnum;
 
@@ -78,6 +79,19 @@ final class AttributeBagProvider
     }
 
     /**
+     * @phpstan-return array<string, array{mixed[], string}>
+     */
+    public static function invalidManyKey(): array
+    {
+        return [
+            'integer key in values array' => [
+                [1 => 'value'],
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+        ];
+    }
+
+    /**
      * @phpstan-return array<string, array{mixed[], mixed[], mixed[]}>
      */
     public static function merge(): array
@@ -108,74 +122,70 @@ final class AttributeBagProvider
     /**
      * @phpstan-return array<
      *   string,
-     *   array{
-     *     mixed[],
-     *     mixed,
-     *     bool|float|int|string|\Closure(): mixed|\Stringable|UnitEnum|null,
-     *     string,
-     *     bool,
-     *     mixed[],
-     *   },
+     *   array{mixed[], string|UnitEnum, bool|float|int|string|\Closure(): mixed|\Stringable|UnitEnum|null, mixed[]},
      * >
      */
     public static function set(): array
     {
+        $closure = static fn(): string => 'submit';
+
         return [
-            'boolean to string conversion disabled by default' => [
+            'keeps closure value as raw data' => [
                 [],
-                'disabled',
-                true,
-                '',
-                false,
-                ['disabled' => true],
+                'id',
+                $closure,
+                ['id' => $closure],
             ],
-            'boolean to string conversion enabled' => [
+            'keeps enum value as raw data' => [
                 [],
-                'hidden',
-                false,
-                'aria-',
-                true,
-                ['aria-hidden' => 'false'],
+                'type',
+                BackedInteger::VALUE,
+                ['type' => BackedInteger::VALUE],
             ],
-            'resolves closure value' => [
-                [],
-                'label',
-                static fn(): string => 'Dynamic label',
-                'aria-',
-                false,
-                ['aria-label' => 'Dynamic label'],
-            ],
-            'supports aria prefix with enum key' => [
-                [],
-                Key::ARIA_LABEL,
-                'Dialog title',
-                'aria-',
-                false,
-                ['aria-label' => 'Dialog title'],
-            ],
-            'supports data prefix with enum key' => [
-                [],
-                Key::DATA_TOGGLE,
-                'dropdown',
-                'data-',
-                false,
-                ['data-toggle' => 'dropdown'],
-            ],
-            'supports on prefix with enum key' => [
-                [],
-                Key::ON_CLICK,
-                'handleClick()',
-                'on',
-                false,
-                ['onclick' => 'handleClick()'],
-            ],
-            'removes key when resolved value is null' => [
+            'removes key when value is null' => [
                 ['data-toggle' => 'modal', 'id' => 'trigger'],
                 Key::DATA_TOGGLE,
-                static fn() => null,
-                'data-',
-                false,
+                null,
                 ['id' => 'trigger'],
+            ],
+            'sets plain attribute value' => [
+                [],
+                'role',
+                'button',
+                ['role' => 'button'],
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<string, array{mixed[], mixed[], mixed[]}>
+     */
+    public static function setMany(): array
+    {
+        $closure = static fn(): string => 'submit';
+
+        return [
+            'sets many plain attributes and removes null values' => [
+                ['id' => 'button'],
+                [
+                    'id' => $closure,
+                    'title' => 'Send form',
+                    'disabled' => null,
+                ],
+                ['id' => $closure, 'title' => 'Send form'],
+            ],
+            'supports prefixed keys from traits' => [
+                [],
+                [
+                    'aria-label' => 'Close modal',
+                    'data-toggle' => 'dropdown',
+                    'onclick' => 'handleClick()',
+                ],
+                [
+                    'aria-label' => 'Close modal',
+                    'data-toggle' => 'dropdown',
+                    'onclick' => 'handleClick()',
+                ],
             ],
         ];
     }

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -20,33 +20,6 @@ use UnitEnum;
 final class AttributeBagProvider
 {
     /**
-     * @phpstan-return array<string, array{mixed[], string|UnitEnum, string|null, mixed[]}>
-     */
-    public static function add(): array
-    {
-        return [
-            'accepts UnitEnum key' => [
-                ['id' => 'btn-save'],
-                Key::ARIA_LABEL,
-                'Save button',
-                ['id' => 'btn-save', 'aria-label' => 'Save button'],
-            ],
-            'sets value by string key' => [
-                ['class' => 'btn'],
-                'role',
-                'button',
-                ['class' => 'btn', 'role' => 'button'],
-            ],
-            'unsets key on null value' => [
-                ['data-toggle' => 'modal', 'id' => 'dialog'],
-                'data-toggle',
-                null,
-                ['id' => 'dialog'],
-            ],
-        ];
-    }
-
-    /**
      * @phpstan-return array<string, array{mixed[], string, string|null, string}>
      */
     public static function get(): array
@@ -84,10 +57,15 @@ final class AttributeBagProvider
     public static function invalidManyKey(): array
     {
         return [
+            'empty string key in values array' => [
+                ['' => 'value'],
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
             'integer key in values array' => [
                 [1 => 'value'],
                 Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
             ],
+
         ];
     }
 

--- a/tests/Provider/AttributesProvider.php
+++ b/tests/Provider/AttributesProvider.php
@@ -350,6 +350,44 @@ final class AttributesProvider
                 ['data-config' => '{"key":"<val>"}'],
                 false,
             ],
+            'on expansion array json encoding with encode false' => [
+                [
+                    'on' => [
+                        'click' => ['payload' => '<tag>'],
+                    ],
+                ],
+                ['onclick' => '{"payload":"<tag>"}'],
+                false,
+            ],
+            'on expansion array json encoding with encode true' => [
+                [
+                    'on' => [
+                        'click' => ['payload' => '<tag>'],
+                    ],
+                ],
+                ['onclick' => '{"payload":"\u0026lt;tag\u0026gt;"}'],
+                true,
+            ],
+            'on expansion keeps exact key on as onon' => [
+                ['on' => ['on' => 'handleOn()']],
+                ['onon' => 'handleOn()'],
+            ],
+            'on expansion preserves prefixed key' => [
+                ['on' => ['onclick' => 'handleClick()']],
+                ['onclick' => 'handleClick()'],
+            ],
+            'on expansion supports float value' => [
+                ['on' => ['wheel' => 3.14]],
+                ['onwheel' => '3.14'],
+            ],
+            'on expansion supports integer value' => [
+                ['on' => ['keyup' => 13]],
+                ['onkeyup' => '13'],
+            ],
+            'on expansion with short event key' => [
+                ['on' => ['click' => 'handleClick()']],
+                ['onclick' => 'handleClick()'],
+            ],
             'simple string' => [
                 ['id' => 'my-id'],
                 ['id' => 'my-id'],
@@ -555,6 +593,16 @@ final class AttributesProvider
                     'ng' => [
                         'a' => 1,
                         'b' => 'c',
+                    ],
+                ],
+            ],
+            'src and on' => [
+                ' src="xyz" onclick="handleClick()" onsubmit="return false"',
+                [
+                    'src' => 'xyz',
+                    'on' => [
+                        'click' => 'handleClick()',
+                        'onsubmit' => 'return false',
                     ],
                 ],
             ],

--- a/tests/Provider/AttributesProvider.php
+++ b/tests/Provider/AttributesProvider.php
@@ -368,9 +368,9 @@ final class AttributesProvider
                 ['onclick' => '{"payload":"\u0026lt;tag\u0026gt;"}'],
                 true,
             ],
-            'on expansion keeps exact key on as onon' => [
+            'on expansion keeps exact key on' => [
                 ['on' => ['on' => 'handleOn()']],
-                ['onon' => 'handleOn()'],
+                ['on' => 'handleOn()'],
             ],
             'on expansion preserves prefixed key' => [
                 ['on' => ['onclick' => 'handleClick()']],
@@ -383,6 +383,10 @@ final class AttributesProvider
             'on expansion supports integer value' => [
                 ['on' => ['keyup' => 13]],
                 ['onkeyup' => '13'],
+            ],
+            'on expansion defaults unsupported scalar to empty string' => [
+                ['on' => ['click' => true]],
+                ['onclick' => ''],
             ],
             'on expansion with short event key' => [
                 ['on' => ['click' => 'handleClick()']],


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
