### PR TITLE
feat(helper): Move `normalizeKey()` to `AttributeBag` and add optional `$prefix` support to `get()`, `remove()`, `set()`, and `setMany()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.2 Under development
 
+- Enh: Move `normalizeKey()` to `AttributeBag` and add optional `$prefix` support to `get()`, `remove()`, `set()`, and `setMany()` (@terabytesoftw)
+
 ## 0.7.1 February 15, 2026
 
 - Bug #50: Serialize boolean values in `aria-*`, `data-*`, `data-ng`, `ng-*`, and `on*` attributes as explicit strings (@terabytesoftw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.2 Under development
 
-- Enh: Move `normalizeKey()` to `AttributeBag` and add optional `$prefix` support to `get()`, `remove()`, `set()`, and `setMany()` (@terabytesoftw)
+- Enh #52: Move `normalizeKey()` to `AttributeBag` and add optional `$prefix` support to `get()`, `remove()`, `set()`, and `setMany()` (@terabytesoftw)
 
 ## 0.7.1 February 15, 2026
 

--- a/src/Base/BaseAttributeBag.php
+++ b/src/Base/BaseAttributeBag.php
@@ -199,6 +199,7 @@ abstract class BaseAttributeBag
      *     ['label' => 'Submit'],
      *     'aria-',
      * );
+     * ```
      *
      * @param array $attributes Attribute bag to update in place.
      * @param array $values Values to set.

--- a/src/Base/BaseAttributeBag.php
+++ b/src/Base/BaseAttributeBag.php
@@ -14,6 +14,7 @@ use function array_key_exists;
 use function is_bool;
 use function is_string;
 use function preg_match;
+use function str_starts_with;
 
 /**
  * Provides reusable operations for associative HTML attribute bags.
@@ -30,11 +31,13 @@ abstract class BaseAttributeBag
      * ```php
      * \UIAwesome\Html\Helper\AttributeBag::get($attributes, 'id');
      * \UIAwesome\Html\Helper\AttributeBag::get($attributes, 'type', 'button');
+     * \UIAwesome\Html\Helper\AttributeBag::get($attributes, 'label', null, 'aria-');
      * ```
      *
      * @param array $attributes Attribute bag.
      * @param string|UnitEnum $key Attribute key.
      * @param mixed $default Default value when key is not present.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @throws InvalidArgumentException if normalized key is not a non-empty `string`.
      *
@@ -42,9 +45,13 @@ abstract class BaseAttributeBag
      *
      * @phpstan-param mixed[] $attributes
      */
-    public static function get(array $attributes, string|UnitEnum $key, mixed $default = null): mixed
-    {
-        $normalizedKey = self::normalizeKey($key);
+    public static function get(
+        array $attributes,
+        string|UnitEnum $key,
+        mixed $default = null,
+        string $prefix = '',
+    ): mixed {
+        $normalizedKey = self::normalizeKey($key, $prefix);
 
         return array_key_exists($normalizedKey, $attributes)
             ? $attributes[$normalizedKey]
@@ -81,23 +88,60 @@ abstract class BaseAttributeBag
     }
 
     /**
+     * Normalizes an attribute key ensuring it has a specific prefix.
+     *
+     * Returns the key unchanged when it already has the prefix.
+     *
+     * Usage example:
+     * ```php
+     * \UIAwesome\Html\Helper\AttributeBag::normalizeKey('label', 'aria-');
+     * // 'aria-label'
+     * ```
+     *
+     * @param mixed $key Key to normalize. Accepts strings, Stringable objects, or UnitEnum cases.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
+     *
+     * @throws InvalidArgumentException if the key is empty, not a `string`, or cannot be normalized to a `string`.
+     *
+     * @return string Normalized key with the prefix ensured.
+     */
+    public static function normalizeKey(mixed $key, string $prefix): string
+    {
+        $normalizedKey = Enum::normalizeValue($key);
+
+        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
+            throw new InvalidArgumentException(
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            );
+        }
+
+        if (str_starts_with($normalizedKey, $prefix) === false) {
+            return "{$prefix}{$normalizedKey}";
+        }
+
+        return $normalizedKey;
+    }
+
+    /**
      * Removes an attribute from the bag.
      *
      * Usage example:
      * ```php
      * \UIAwesome\Html\Helper\AttributeBag::remove($attributes, 'disabled');
+     * \UIAwesome\Html\Helper\AttributeBag::remove($attributes, 'label', 'aria-');
      * ```
      *
      * @param array $attributes Attribute bag to update in place.
      * @param string|UnitEnum $key Attribute key.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @throws InvalidArgumentException if normalized key is not a non-empty `string`.
      *
      * @phpstan-param mixed[] $attributes
      */
-    public static function remove(array &$attributes, string|UnitEnum $key): void
+    public static function remove(array &$attributes, string|UnitEnum $key, string $prefix = ''): void
     {
-        $normalizedKey = self::normalizeKey($key);
+        $normalizedKey = self::normalizeKey($key, $prefix);
 
         unset($attributes[$normalizedKey]);
     }
@@ -110,19 +154,21 @@ abstract class BaseAttributeBag
      * $attributes = [];
      * \UIAwesome\Html\Helper\AttributeBag::set($attributes, 'disabled', true);
      * \UIAwesome\Html\Helper\AttributeBag::set($attributes, 'id', static fn () => 'submit');
+     * \UIAwesome\Html\Helper\AttributeBag::set($attributes, 'label', 'Submit', 'aria-');
      * ```
      *
      * @param array $attributes Attribute bag to update in place.
      * @param string|UnitEnum $key Attribute key to normalize.
      * @param mixed $value Attribute value.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @throws InvalidArgumentException if key normalization fails.
      *
      * @phpstan-param mixed[] $attributes
      */
-    public static function set(array &$attributes, string|UnitEnum $key, mixed $value): void
+    public static function set(array &$attributes, string|UnitEnum $key, mixed $value, string $prefix = ''): void
     {
-        $normalizedKey = self::normalizeKey($key);
+        $normalizedKey = self::normalizeKey($key, $prefix);
 
         if ($value instanceof Closure) {
             $value = $value();
@@ -138,41 +184,36 @@ abstract class BaseAttributeBag
     /**
      * Sets multiple plain attributes.
      *
+     * Usage example:
+     * ```php
+     * $attributes = [];
+     * \UIAwesome\Html\Helper\AttributeBag::setMany(
+     *     $attributes,
+     *     [
+     *         'disabled' => true,
+     *         'id' => static fn () => 'submit',
+     *     ],
+     * );
+     * \UIAwesome\Html\Helper\AttributeBag::setMany(
+     *     $attributes,
+     *     ['label' => 'Submit'],
+     *     'aria-',
+     * );
+     *
      * @param array $attributes Attribute bag to update in place.
      * @param array $values Values to set.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @throws InvalidArgumentException if any key normalization fails.
      *
      * @phpstan-param mixed[] $attributes
      * @phpstan-param mixed[] $values
      */
-    public static function setMany(array &$attributes, array $values): void
+    public static function setMany(array &$attributes, array $values, string $prefix = ''): void
     {
         foreach ($values as $key => $value) {
-            self::set($attributes, self::prepareManyKey($key), $value);
+            self::set($attributes, self::prepareManyKey($key), $value, $prefix);
         }
-    }
-
-    /**
-     * Normalizes an attribute bag key using enum-aware normalization.
-     *
-     * @param string|UnitEnum $key Attribute key.
-     *
-     * @throws InvalidArgumentException if normalized key is not a non-empty `string`.
-     *
-     * @return string Normalized key.
-     */
-    private static function normalizeKey(string|UnitEnum $key): string
-    {
-        $normalizedKey = Enum::normalizeValue($key);
-
-        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
-            throw new InvalidArgumentException(
-                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
-            );
-        }
-
-        return $normalizedKey;
     }
 
     /**

--- a/src/Base/BaseAttributes.php
+++ b/src/Base/BaseAttributes.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Helper\Base;
 
 use Closure;
-use InvalidArgumentException;
 use UIAwesome\Html\Helper\{Encode, Enum};
-use UIAwesome\Html\Helper\Exception\Message;
 
 use function array_map;
 use function implode;
@@ -147,41 +145,6 @@ abstract class BaseAttributes
         }
 
         return $normalized;
-    }
-
-    /**
-     * Normalizes an attribute key ensuring it has a specific prefix.
-     *
-     * Returns the key unchanged when it already has the prefix.
-     *
-     * Usage example:
-     * ```php
-     * \UIAwesome\Html\Helper\Attributes::normalizeKey('label', 'aria-');
-     * // 'aria-label'
-     * ```
-     *
-     * @param mixed $key Key to normalize. Accepts strings, Stringable objects, or UnitEnum cases.
-     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
-     *
-     * @throws InvalidArgumentException if the key is empty, not a `string`, or cannot be normalized to a `string`.
-     *
-     * @return string Normalized key with the prefix ensured.
-     */
-    public static function normalizeKey(mixed $key, string $prefix): string
-    {
-        $normalizedKey = Enum::normalizeValue($key);
-
-        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
-            throw new InvalidArgumentException(
-                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
-            );
-        }
-
-        if (str_starts_with($normalizedKey, $prefix) === false) {
-            return "{$prefix}{$normalizedKey}";
-        }
-
-        return $normalizedKey;
     }
 
     /**

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -50,6 +50,25 @@ final class AttributeBagTest extends TestCase
 
     /**
      * @phpstan-param mixed[] $attributes
+     * @phpstan-param string|UnitEnum $key
+     */
+    #[DataProviderExternal(AttributeBagProvider::class, 'getWithPrefix')]
+    public function testGetWithPrefix(
+        array $attributes,
+        string|UnitEnum $key,
+        string $prefix,
+        mixed $default,
+        mixed $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            AttributeBag::get($attributes, $key, $default, $prefix),
+            'Should return existing prefixed value or fallback default.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
      * @phpstan-param mixed[] $values
      */
     #[DataProviderExternal(AttributeBagProvider::class, 'merge')]
@@ -61,6 +80,16 @@ final class AttributeBagTest extends TestCase
             $expected,
             Attributes::render($attributes),
             'Should merge values and override duplicated keys in rendered output.',
+        );
+    }
+
+    #[DataProviderExternal(AttributeBagProvider::class, 'key')]
+    public function testNormalizeKeyAttribute(mixed $key, string $prefix, string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            AttributeBag::normalizeKey($key, $prefix),
+            'Should normalize key attribute correctly.',
         );
     }
 
@@ -77,6 +106,22 @@ final class AttributeBagTest extends TestCase
             $expected,
             Attributes::render($attributes),
             'Should remove the specified key in rendered output.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     * @phpstan-param string|UnitEnum $key
+     */
+    #[DataProviderExternal(AttributeBagProvider::class, 'removeWithPrefix')]
+    public function testRemoveWithPrefix(array $attributes, string|UnitEnum $key, string $prefix, string $expected): void
+    {
+        AttributeBag::remove($attributes, $key, $prefix);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($attributes),
+            'Should remove the specified prefixed key in rendered output.',
         );
     }
 
@@ -114,6 +159,54 @@ final class AttributeBagTest extends TestCase
             Attributes::render($attributes),
             "Should set many plain attributes and remove keys with 'null' values in rendered output.",
         );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     * @phpstan-param mixed[] $values
+     */
+    #[DataProviderExternal(AttributeBagProvider::class, 'setManyWithPrefix')]
+    public function testSetManyWithPrefix(array $attributes, array $values, string $prefix, string $expected): void
+    {
+        AttributeBag::setMany($attributes, $values, $prefix);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($attributes),
+            "Should set many prefixed attributes and remove normalized keys with 'null' values.",
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     * @phpstan-param string|UnitEnum $key
+     */
+    #[DataProviderExternal(AttributeBagProvider::class, 'setWithPrefix')]
+    public function testSetWithPrefix(
+        array $attributes,
+        string|UnitEnum $key,
+        mixed $value,
+        string $prefix,
+        string $expected,
+    ): void {
+        AttributeBag::set($attributes, $key, $value, $prefix);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($attributes),
+            'Should set prefixed attributes with normalized keys and serialized booleans.',
+        );
+    }
+
+    #[DataProviderExternal(AttributeBagProvider::class, 'invalidKey')]
+    public function testThrowInvalidArgumentExceptionForAttributeKeyIsInvalid(mixed $key, string $prefix): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+        );
+
+        AttributeBag::normalizeKey($key, $prefix);
     }
 
     #[DataProviderExternal(AttributeBagProvider::class, 'invalidKey')]

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -198,7 +198,7 @@ final class AttributeBagTest extends TestCase
         );
     }
 
-    #[DataProviderExternal(AttributeBagProvider::class, 'invalidKey')]
+    #[DataProviderExternal(AttributeBagProvider::class, 'normalizeInvalidKey')]
     public function testThrowInvalidArgumentExceptionForAttributeKeyIsInvalid(mixed $key, string $prefix): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Helper\Tests;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Helper\Attributes;
-use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Helper\Tests\Provider\AttributesProvider;
 
 /**
@@ -48,16 +46,6 @@ final class AttributesTest extends TestCase
             $expected,
             $normalizeAttribute,
             'Should normalize attributes returning the expected array structure.',
-        );
-    }
-
-    #[DataProviderExternal(AttributesProvider::class, 'key')]
-    public function testNormalizeKeyAttribute(mixed $key, string $prefix, string $expected): void
-    {
-        self::assertSame(
-            $expected,
-            Attributes::normalizeKey($key, $prefix),
-            'Should normalize key attribute correctly.',
         );
     }
 
@@ -137,16 +125,5 @@ final class AttributesTest extends TestCase
             Attributes::render($attributes),
             'Should render attributes as expected for each data set.',
         );
-    }
-
-    #[DataProviderExternal(AttributesProvider::class, 'invalidKey')]
-    public function testThrowInvalidArgumentExceptionForAttributeKeyIsInvalid(mixed $key, string $prefix): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
-        );
-
-        Attributes::normalizeKey($key, $prefix);
     }
 }

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -82,6 +82,13 @@ final class AttributeBagProvider
                 'fallback',
                 'handleClick()',
             ],
+            'enum key with prefix' => [
+                ['aria-label' => 'Close'],
+                Key::ARIA_LABEL,
+                'aria-',
+                'fallback',
+                'Close',
+            ],
             'ng value by unprefixed key' => [
                 ['ng-if' => 'isVisible'],
                 'if',
@@ -311,6 +318,12 @@ final class AttributeBagProvider
                 ['id' => 'submit', 'onclick' => 'handleClick()'],
                 'click',
                 'on',
+                ' id="submit"',
+            ],
+            'enum key with prefix' => [
+                ['id' => 'submit', 'data-toggle' => 'dropdown'],
+                Key::DATA_TOGGLE,
+                'data-',
                 ' id="submit"',
             ],
             'ng key with prefix' => [
@@ -599,6 +612,13 @@ final class AttributeBagProvider
                 'on',
                 ' onchange="handleChange()"',
             ],
+            'enum key with prefix' => [
+                [],
+                Key::ON_CLICK,
+                'handleClick()',
+                'on',
+                ' onclick="handleClick()"',
+            ],
             'ng boolean false when key is unprefixed' => [
                 [],
                 'if',
@@ -612,6 +632,13 @@ final class AttributeBagProvider
                 1,
                 'ng-',
                 ' ng-bind="1"',
+            ],
+            'removes prefixed key when value is null' => [
+                ['aria-label' => 'Close'],
+                'label',
+                null,
+                'aria-',
+                '',
             ],
         ];
     }

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -93,19 +93,13 @@ final class AttributeBagProvider
     }
 
     /**
-     * @phpstan-return array<string, array{mixed, string}>
+     * @phpstan-return array<string, array<string|UnitEnum>>
      */
     public static function invalidKey(): array
     {
         return [
-            'empty string' => [
-                '',
-                '',
-            ],
-            'int backed enum' => [
-                BackedInteger::VALUE,
-                '',
-            ],
+            'empty string' => [''],
+            'int backed enum' => [BackedInteger::VALUE],
         ];
     }
 
@@ -256,6 +250,23 @@ final class AttributeBagProvider
     }
 
     /**
+     * @phpstan-return array<string, array{string|UnitEnum, string}>
+     */
+    public static function normalizeInvalidKey(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                '',
+            ],
+            'int backed enum' => [
+                BackedInteger::VALUE,
+                '',
+            ],
+        ];
+    }
+
+    /**
      * @phpstan-return array<string, array{mixed[], string|UnitEnum, string}>
      */
     public static function remove(): array
@@ -294,6 +305,12 @@ final class AttributeBagProvider
                 ['id' => 'submit', 'data-ng-model' => 'email'],
                 'model',
                 'data-ng-',
+                ' id="submit"',
+            ],
+            'event key with prefix' => [
+                ['id' => 'submit', 'onclick' => 'handleClick()'],
+                'click',
+                'on',
                 ' id="submit"',
             ],
             'ng key with prefix' => [

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Helper\Tests\Provider;
 
 use PHPForge\Support\Stub\BackedInteger;
+use Stringable;
 use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Helper\Tests\Support\Key;
 use UnitEnum;
@@ -25,13 +26,13 @@ final class AttributeBagProvider
     public static function get(): array
     {
         return [
-            'returns default when missing' => [
+            'default when missing' => [
                 ['id' => 'submit'],
                 'title',
                 'fallback',
                 'fallback',
             ],
-            'returns existing value' => [
+            'existing value' => [
                 ['role' => 'button'],
                 'role',
                 null,
@@ -41,13 +42,70 @@ final class AttributeBagProvider
     }
 
     /**
-     * @phpstan-return array<string, array{string|UnitEnum}>
+     * @phpstan-return array<string, array{mixed[], string|UnitEnum, string, mixed, mixed}>
+     */
+    public static function getWithPrefix(): array
+    {
+        return [
+            'aria value by unprefixed key' => [
+                ['aria-expanded' => 'true'],
+                'expanded',
+                'aria-',
+                'fallback',
+                'true',
+            ],
+            'data value by unprefixed key' => [
+                ['data-toggle' => 'dropdown'],
+                'toggle',
+                'data-',
+                'fallback',
+                'dropdown',
+            ],
+            'data-ng value by unprefixed key' => [
+                ['data-ng-model' => 'profile.email'],
+                'model',
+                'data-ng-',
+                'fallback',
+                'profile.email',
+            ],
+            'default when prefixed key is missing' => [
+                ['data-target' => '#modal'],
+                'toggle',
+                'data-',
+                'fallback',
+                'fallback',
+            ],
+            'event value by unprefixed key' => [
+                ['onclick' => 'handleClick()'],
+                'click',
+                'on',
+                'fallback',
+                'handleClick()',
+            ],
+            'ng value by unprefixed key' => [
+                ['ng-if' => 'isVisible'],
+                'if',
+                'ng-',
+                'fallback',
+                'isVisible',
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<string, array{mixed, string}>
      */
     public static function invalidKey(): array
     {
         return [
-            'empty string' => [''],
-            'int backed enum' => [BackedInteger::VALUE],
+            'empty string' => [
+                '',
+                '',
+            ],
+            'int backed enum' => [
+                BackedInteger::VALUE,
+                '',
+            ],
         ];
     }
 
@@ -69,14 +127,129 @@ final class AttributeBagProvider
     }
 
     /**
+     * @phpstan-return array<string, array{string|Stringable|UnitEnum, string, string}>
+     */
+    public static function key(): array
+    {
+        return [
+            'already prefixed data-ng' => [
+                'data-ng-model',
+                'data-ng-',
+                'data-ng-model',
+            ],
+            'already prefixed ng' => [
+                'ng-if',
+                'ng-',
+                'ng-if',
+            ],
+            'already prefixed on' => [
+                'onsubmit',
+                'on',
+                'onsubmit',
+            ],
+            'enum with prefix aria' => [
+                Key::ARIA_LABEL,
+                'aria-',
+                'aria-label',
+            ],
+            'enum with prefix data' => [
+                Key::DATA_TOGGLE,
+                'data-',
+                'data-toggle',
+            ],
+            'enum with prefix event' => [
+                Key::ON_CLICK,
+                'on',
+                'onclick',
+            ],
+            'string key with prefix aria' => [
+                'aria-label',
+                'aria-',
+                'aria-label',
+            ],
+            'string key with prefix data' => [
+                'data-toggle',
+                'data-',
+                'data-toggle',
+            ],
+            'string key with prefix event' => [
+                'onclick',
+                'on',
+                'onclick',
+            ],
+            'stringable with prefix aria' => [
+                new class {
+                    public function __toString(): string
+                    {
+                        return 'aria-label';
+                    }
+                },
+                'aria-',
+                'aria-label',
+            ],
+            'stringable with prefix data' => [
+                new class {
+                    public function __toString(): string
+                    {
+                        return 'data-toggle';
+                    }
+                },
+                'data-',
+                'data-toggle',
+            ],
+            'stringable with prefix event' => [
+                new class {
+                    public function __toString(): string
+                    {
+                        return 'onclick';
+                    }
+                },
+                'on',
+                'onclick',
+            ],
+            'without prefix aria' => [
+                'label',
+                'aria-',
+                'aria-label',
+            ],
+            'without prefix data' => [
+                'toggle',
+                'data-',
+                'data-toggle',
+            ],
+            'without prefix data-ng' => [
+                'model',
+                'data-ng-',
+                'data-ng-model',
+            ],
+            'without prefix ng' => [
+                'if',
+                'ng-',
+                'ng-if',
+            ],
+            'without prefix event' => [
+                'click',
+                'on',
+                'onclick',
+            ],
+        ];
+    }
+
+    /**
      * @phpstan-return array<string, array{mixed[], mixed[], string}>
      */
     public static function merge(): array
     {
         return [
             'merges and overrides existing keys' => [
-                ['class' => 'btn', 'id' => 'submit'],
-                ['class' => 'btn btn-primary', 'title' => 'Submit'],
+                [
+                    'class' => 'btn',
+                    'id' => 'submit',
+                ],
+                [
+                    'class' => 'btn btn-primary',
+                    'title' => 'Submit',
+                ],
                 ' class="btn btn-primary" id="submit" title="Submit"',
             ],
         ];
@@ -89,8 +262,44 @@ final class AttributeBagProvider
     {
         return [
             'removes existing key' => [
-                ['id' => 'submit', 'role' => 'button'],
+                [
+                    'id' => 'submit',
+                    'role' => 'button',
+                ],
                 'role',
+                ' id="submit"',
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<string, array{mixed[], string|UnitEnum, string, string}>
+     */
+    public static function removeWithPrefix(): array
+    {
+        return [
+            'aria key with prefix' => [
+                ['id' => 'submit', 'aria-expanded' => 'true'],
+                'expanded',
+                'aria-',
+                ' id="submit"',
+            ],
+            'data key with prefix' => [
+                ['id' => 'submit', 'data-toggle' => 'dropdown'],
+                'toggle',
+                'data-',
+                ' id="submit"',
+            ],
+            'data-ng key with prefix' => [
+                ['id' => 'submit', 'data-ng-model' => 'email'],
+                'model',
+                'data-ng-',
+                ' id="submit"',
+            ],
+            'ng key with prefix' => [
+                ['id' => 'submit', 'ng-if' => 'isVisible'],
+                'if',
+                'ng-',
                 ' id="submit"',
             ],
         ];
@@ -107,11 +316,17 @@ final class AttributeBagProvider
         $closure = static fn(): string => 'submit';
 
         return [
-            'does not stringify boolean for non-prefixed key containing aria substring' => [
+            'aria attribute with boolean false value' => [
                 [],
-                'foo-aria-pressed',
+                'aria-expanded',
+                false,
+                ' aria-expanded="false"',
+            ],
+            'aria attribute with boolean true value' => [
+                [],
+                'aria-pressed',
                 true,
-                ' foo-aria-pressed',
+                ' aria-pressed="true"',
             ],
             'closure with boolean false' => [
                 [],
@@ -125,6 +340,48 @@ final class AttributeBagProvider
                 static fn(): bool => true,
                 ' aria-pressed="true"',
             ],
+            'data attribute with boolean false value' => [
+                [],
+                'data-active',
+                false,
+                ' data-active="false"',
+            ],
+            'data attribute with boolean true value' => [
+                [],
+                'data-active',
+                true,
+                ' data-active="true"',
+            ],
+            'data-ng attribute with boolean false value' => [
+                [],
+                'data-ng-required',
+                false,
+                ' data-ng-required="false"',
+            ],
+            'data-ng attribute with boolean true value' => [
+                [],
+                'data-ng-required',
+                true,
+                ' data-ng-required="true"',
+            ],
+            'does not stringify boolean for non-prefixed key containing aria substring' => [
+                [],
+                'foo-aria-pressed',
+                true,
+                ' foo-aria-pressed',
+            ],
+            'event attribute with boolean false value' => [
+                [],
+                'onclick',
+                false,
+                ' onclick="false"',
+            ],
+            'event attribute with boolean true value' => [
+                [],
+                'onclick',
+                true,
+                ' onclick="true"',
+            ],
             'keeps closure value as raw data' => [
                 [],
                 'id',
@@ -137,29 +394,29 @@ final class AttributeBagProvider
                 BackedInteger::VALUE,
                 ' type="1"',
             ],
+            'ng attribute with boolean false value' => [
+                [],
+                'ng-required',
+                false,
+                ' ng-required="false"',
+            ],
+            'ng attribute with boolean true value' => [
+                [],
+                'ng-required',
+                true,
+                ' ng-required="true"',
+            ],
+            'plain attribute value' => [
+                [],
+                'role',
+                'button',
+                ' role="button"',
+            ],
             'removes key when value is null' => [
                 ['data-toggle' => 'modal', 'id' => 'trigger'],
                 Key::DATA_TOGGLE,
                 null,
                 ' id="trigger"',
-            ],
-            'sets aria attribute with boolean true value' => [
-                [],
-                'aria-pressed',
-                true,
-                ' aria-pressed="true"',
-            ],
-            'sets aria attribute with boolean false value' => [
-                [],
-                'aria-expanded',
-                false,
-                ' aria-expanded="false"',
-            ],
-            'sets plain attribute value' => [
-                [],
-                'role',
-                'button',
-                ' role="button"',
             ],
         ];
     }
@@ -172,7 +429,7 @@ final class AttributeBagProvider
         $closure = static fn(): string => 'submit';
 
         return [
-            'sets many plain attributes and removes null values' => [
+            'many plain attributes and removes null values' => [
                 ['id' => 'button'],
                 [
                     'id' => $closure,
@@ -181,7 +438,7 @@ final class AttributeBagProvider
                 ],
                 ' id="submit" title="Send form"',
             ],
-            'supports prefixed keys from traits' => [
+            'prefixed keys from traits' => [
                 [],
                 [
                     'aria-label' => 'Close modal',
@@ -189,6 +446,144 @@ final class AttributeBagProvider
                     'onclick' => 'handleClick()',
                 ],
                 ' aria-label="Close modal" data-toggle="dropdown" onclick="handleClick()"',
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{mixed[], mixed[], string, string},
+     * >
+     */
+    public static function setManyWithPrefix(): array
+    {
+        return [
+            'aria values with bool stringification and null removal' => [
+                ['aria-hidden' => 'true'],
+                [
+                    'label' => 'Dialog',
+                    'expanded' => true,
+                    'hidden' => null,
+                    'controls' => static fn(): string => 'panel-1',
+                ],
+                'aria-',
+                ' aria-label="Dialog" aria-expanded="true" aria-controls="panel-1"',
+            ],
+            'data values with bool stringification and null removal' => [
+                ['data-disabled' => 'false'],
+                [
+                    'toggle' => 'dropdown',
+                    'active' => false,
+                    'disabled' => null,
+                    'count' => static fn(): int => 3,
+                ],
+                'data-',
+                ' data-toggle="dropdown" data-active="false" data-count="3"',
+            ],
+            'data-ng values with bool stringification and null removal' => [
+                ['data-ng-disabled' => 'true'],
+                [
+                    'model' => 'profile.email',
+                    'required' => true,
+                    'disabled' => null,
+                    'order' => static fn(): int => 1,
+                ],
+                'data-ng-',
+                ' data-ng-model="profile.email" data-ng-required="true" data-ng-order="1"',
+            ],
+            'ng values with bool stringification and null removal' => [
+                ['ng-hide' => '1'],
+                [
+                    'if' => 'isVisible',
+                    'disabled' => false,
+                    'hide' => null,
+                    'repeat' => static fn(): string => 'item in items',
+                ],
+                'ng-',
+                ' ng-if="isVisible" ng-disabled="false" ng-repeat="item in items"',
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{mixed[], string|UnitEnum, bool|float|int|string|\Closure(): mixed|\Stringable|UnitEnum|null, string, string},
+     * >
+     */
+    public static function setWithPrefix(): array
+    {
+        return [
+            'aria boolean true when key is unprefixed' => [
+                [],
+                'expanded',
+                true,
+                'aria-',
+                ' aria-expanded="true"',
+            ],
+            'aria scalar value with key normalization' => [
+                [],
+                'label',
+                'Dialog',
+                'aria-',
+                ' aria-label="Dialog"',
+            ],
+            'data boolean false when key is unprefixed' => [
+                [],
+                'toggle',
+                false,
+                'data-',
+                ' data-toggle="false"',
+            ],
+            'data scalar value with key normalization' => [
+                [],
+                'count',
+                2,
+                'data-',
+                ' data-count="2"',
+            ],
+            'data-ng boolean true when key is unprefixed' => [
+                [],
+                'model',
+                true,
+                'data-ng-',
+                ' data-ng-model="true"',
+            ],
+            'data-ng scalar value with key normalization' => [
+                [],
+                'repeat',
+                'item in items',
+                'data-ng-',
+                ' data-ng-repeat="item in items"',
+            ],
+            'event boolean true when key is unprefixed' => [
+                [],
+                'click',
+                true,
+                'on',
+                ' onclick="true"',
+            ],
+            'event scalar value with key normalization' => [
+                [],
+                'change',
+                'handleChange()',
+                'on',
+                ' onchange="handleChange()"',
+            ],
+            'ng boolean false when key is unprefixed' => [
+                [],
+                'if',
+                false,
+                'ng-',
+                ' ng-if="false"',
+            ],
+            'ng scalar value with key normalization' => [
+                [],
+                'bind',
+                1,
+                'ng-',
+                ' ng-bind="1"',
             ],
         ];
     }

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -446,7 +446,7 @@ final class AttributeBagProvider
         $closure = static fn(): string => 'submit';
 
         return [
-            'many plain attributes and removes null values' => [
+            'plain attributes and removes null values' => [
                 ['id' => 'button'],
                 [
                     'id' => $closure,
@@ -508,6 +508,17 @@ final class AttributeBagProvider
                 ],
                 'data-ng-',
                 ' data-ng-model="profile.email" data-ng-required="true" data-ng-order="1"',
+            ],
+            'event values with bool stringification and null removal' => [
+                ['onclick' => 'old()'],
+                [
+                    'change' => 'handleChange()',
+                    'submit' => true,
+                    'click' => null,
+                    'focus' => static fn(): string => 'handleFocus()',
+                ],
+                'on',
+                ' onchange="handleChange()" onsubmit="true" onfocus="handleFocus()"',
             ],
             'ng values with bool stringification and null removal' => [
                 ['ng-hide' => '1'],

--- a/tests/Provider/AttributesProvider.php
+++ b/tests/Provider/AttributesProvider.php
@@ -6,8 +6,6 @@ namespace UIAwesome\Html\Helper\Tests\Provider;
 
 use PHPForge\Support\Stub\{BackedInteger, BackedString};
 use Stringable;
-use UIAwesome\Html\Helper\Tests\Support\Key;
-use UnitEnum;
 
 /**
  * Data provider for {@see \UIAwesome\Html\Helper\Tests\AttributesTest} test cases.
@@ -114,107 +112,6 @@ final class AttributesProvider
             'single enum' => [
                 ' type="value"',
                 ['type' => BackedString::VALUE],
-            ],
-        ];
-    }
-
-    /**
-     * @phpstan-return array<string, array{string|UnitEnum, string}>
-     */
-    public static function invalidKey(): array
-    {
-        return [
-            'empty string' => [
-                '',
-                'aria-',
-            ],
-            'enum' => [
-                BackedInteger::VALUE,
-                'data-',
-            ],
-        ];
-    }
-
-    /**
-     * @phpstan-return array<string, array{string|Stringable|UnitEnum, string, string}>
-     */
-    public static function key(): array
-    {
-        return [
-            'enum with prefix aria' => [
-                Key::ARIA_LABEL,
-                'aria-',
-                'aria-label',
-            ],
-            'enum with prefix data' => [
-                Key::DATA_TOGGLE,
-                'data-',
-                'data-toggle',
-            ],
-            'enum with prefix event' => [
-                Key::ON_CLICK,
-                'on',
-                'onclick',
-            ],
-            'string key with prefix aria' => [
-                'aria-label',
-                'aria-',
-                'aria-label',
-            ],
-            'string key with prefix data' => [
-                'data-toggle',
-                'data-',
-                'data-toggle',
-            ],
-            'string key with prefix event' => [
-                'onclick',
-                'on',
-                'onclick',
-            ],
-            'stringable with prefix aria' => [
-                new class {
-                    public function __toString(): string
-                    {
-                        return 'aria-label';
-                    }
-                },
-                'aria-',
-                'aria-label',
-            ],
-            'stringable with prefix data' => [
-                new class {
-                    public function __toString(): string
-                    {
-                        return 'data-toggle';
-                    }
-                },
-                'data-',
-                'data-toggle',
-            ],
-            'stringable with prefix event' => [
-                new class {
-                    public function __toString(): string
-                    {
-                        return 'onclick';
-                    }
-                },
-                'on',
-                'onclick',
-            ],
-            'without prefix aria' => [
-                'label',
-                'aria-',
-                'aria-label',
-            ],
-            'without prefix data' => [
-                'toggle',
-                'data-',
-                'data-toggle',
-            ],
-            'without prefix event' => [
-                'click',
-                'on',
-                'onclick',
             ],
         ];
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
