### PR TITLE
Remove attributes from `AttributeBag` when `set()` receives `null` or a closure resolving to `null`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.3 Under development
 
 - Enh #54: Add `AttributeBag::replace()` and remove unsafe attribute merge behavior while normalizing `null` as removal (@terabytesoftw)
+- Bug #55: Remove attributes from `AttributeBag` when `set()` receives `null` or a closure resolving to `null` (@terabytesoftw)
 
 ## 0.7.2 February 15, 2026
 

--- a/src/Base/BaseAttributeBag.php
+++ b/src/Base/BaseAttributeBag.php
@@ -152,7 +152,7 @@ abstract class BaseAttributeBag
      *
      * @param mixed[] $attributes Attribute bag to update in place.
      * @param string|UnitEnum $key Attribute key to normalize.
-     * @param mixed $value Attribute value.
+     * @param mixed $value Attribute value. Use `null` to remove the attribute.
      * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @throws InvalidArgumentException if key normalization fails.
@@ -163,6 +163,12 @@ abstract class BaseAttributeBag
 
         if ($value instanceof Closure) {
             $value = $value();
+        }
+
+        if ($value === null) {
+            unset($attributes[$normalizedKey]);
+
+            return;
         }
 
         if (is_bool($value) && self::shouldStoreBooleanAsString($normalizedKey)) {

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -199,6 +199,23 @@ final class AttributeBagTest extends TestCase
     }
 
     /**
+     * @param mixed $value Attribute value that resolves to `null`.
+     */
+    #[DataProviderExternal(AttributeBagProvider::class, 'nullValue')]
+    public function testSetWithNullValueRemovesAttributeFromBag(mixed $value): void
+    {
+        $attributes = ['id' => 'submit'];
+
+        AttributeBag::set($attributes, 'id', $value);
+
+        self::assertSame(
+            [],
+            $attributes,
+            'Should remove the attribute from the raw bag when the value resolves to `null`.',
+        );
+    }
+
+    /**
      * @param mixed[] $attributes
      */
     #[DataProviderExternal(AttributeBagProvider::class, 'setWithPrefix')]

--- a/tests/Provider/AttributeBagProvider.php
+++ b/tests/Provider/AttributeBagProvider.php
@@ -254,6 +254,17 @@ final class AttributeBagProvider
     }
 
     /**
+     * @return array<string, array{mixed}>
+     */
+    public static function nullValue(): array
+    {
+        return [
+            'direct null value' => [null],
+            'closure resolving to null' => [static fn(): null => null],
+        ];
+    }
+
+    /**
      * @return array<string, array{mixed[], string|UnitEnum, string}>
      */
     public static function remove(): array


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
